### PR TITLE
로그인/로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-core:${log4j2Version}"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4j2Version}"
     // SQL 로깅 라이브러리
-    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
+    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 
     // ===== XML 처리 관련 =====
     implementation 'xerces:xercesImpl:2.12.2'
@@ -94,6 +94,7 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // ====== Redis 연동 ======
     implementation 'org.springframework.data:spring-data-redis:2.7.5'

--- a/src/main/java/com/guideon/common/redis/RedisKeyUtil.java
+++ b/src/main/java/com/guideon/common/redis/RedisKeyUtil.java
@@ -1,0 +1,23 @@
+package com.guideon.common.redis;
+
+public class RedisKeyUtil {
+    public static String sms(String phone) {
+        return "sms:" + phone;
+    }
+
+    public static String email(String email) {
+        return "email:" + email;
+    }
+
+    public static String resend(String type) {
+        return "resend:" + type;
+    }
+
+    public static String verified(String type) {
+        return "verified:" + type;
+    }
+
+    public static String refreshToken(Long memberId) {
+        return "RT:" + memberId;
+    }
+}

--- a/src/main/java/com/guideon/common/redis/RedisService.java
+++ b/src/main/java/com/guideon/common/redis/RedisService.java
@@ -1,0 +1,56 @@
+package com.guideon.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void blacklistToken(String token, long expirationMillis) {
+        if (expirationMillis <= 0) { redisTemplate.delete(token); return; }
+        redisTemplate.opsForValue().set(token, "logout", expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean isBlacklisted(String token) {
+        return exists(token);
+    }
+
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // 값 저장 (prefix:key 형식, TTL 설정)
+    public void set(String key, String value, int timeoutMinutes) {
+        redisTemplate.opsForValue().set(key, value, timeoutMinutes, TimeUnit.MINUTES);
+    }
+
+    // key 존재하지 않을 시 저장
+    public boolean setIfAbsent(String key, String value, Duration ttl) {
+        return Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent(key, value, ttl));
+    }
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+    // 값 검증 (인증번호 비교)
+    public boolean verify(String key, String inputValue) {
+        String stored = get(key);
+        return inputValue != null && inputValue.equals(stored);
+    }
+
+    public boolean isVerified(String type) {
+        return exists(RedisKeyUtil.verified(type));
+    }
+
+    public boolean exists(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/com/guideon/common/util/PasswordValidator.java
+++ b/src/main/java/com/guideon/common/util/PasswordValidator.java
@@ -1,0 +1,11 @@
+package com.guideon.common.util;
+
+public class PasswordValidator {
+    // 최소 8자, 최대 30자, 영문자(a-zA-Z) 1개 이상, 숫자(0-9) 1개 이상, 특수문자 1개 이상
+    private static final String PASSWORD_REGEX =
+            "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[^a-zA-Z\\d]).{8,30}$";
+
+    public static boolean isValid(String password) {
+        return password != null && password.matches(PASSWORD_REGEX);
+    }
+}

--- a/src/main/java/com/guideon/config/RootConfig.java
+++ b/src/main/java/com/guideon/config/RootConfig.java
@@ -19,8 +19,13 @@ import javax.sql.DataSource;
 
 @Configuration
 @PropertySource({"classpath:/application.properties"})
-//@MapperScan(basePackages = {})
-//@ComponentScan(basePackages = {})
+@MapperScan(basePackages = {
+        "com.guideon.member.mapper",
+})
+@ComponentScan(basePackages = {
+        "com.guideon.member.service",
+        "com.guideon.common.redis",
+})
 @EnableTransactionManagement
 public class RootConfig {
     @Value("${jdbc.driver}") String driver;

--- a/src/main/java/com/guideon/config/ServletConfig.java
+++ b/src/main/java/com/guideon/config/ServletConfig.java
@@ -9,7 +9,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @EnableWebMvc
 @ComponentScan(basePackages = {
-        "com.guideon.exception"
+        "com.guideon.exception",
+        "com.guideon.security.controller",
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/com/guideon/member/domain/Gender.java
+++ b/src/main/java/com/guideon/member/domain/Gender.java
@@ -1,0 +1,29 @@
+package com.guideon.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+    MALE("M"),
+    FEMALE("F");
+
+    private final String code;
+
+    public static Gender fromCode(String code) {
+        for (Gender g : values()) {
+            if (g.code.equalsIgnoreCase(code)) return g;
+        }
+        throw new IllegalArgumentException("Unknown gender code: " + code);
+    }
+
+    public static Gender fromString(String str) {
+        for (Gender g : values()) {
+            if (g.name().equalsIgnoreCase(str)) {
+                return g;
+            }
+        }
+        throw new IllegalArgumentException("Unknown gender code: " + str);
+    }
+}

--- a/src/main/java/com/guideon/member/domain/MemberType.java
+++ b/src/main/java/com/guideon/member/domain/MemberType.java
@@ -1,0 +1,13 @@
+package com.guideon.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberType {
+    INDIVIDUAL("INDIVIDUAL"),
+    SOLE_PROPRIETOR("SOLE_PROPRIETOR");
+
+    private final String code;
+}

--- a/src/main/java/com/guideon/member/dto/MemberDTO.java
+++ b/src/main/java/com/guideon/member/dto/MemberDTO.java
@@ -1,0 +1,48 @@
+package com.guideon.member.dto;
+
+import com.guideon.member.domain.Gender;
+import com.guideon.member.domain.MemberType;
+import com.guideon.security.account.domain.AuthVO;
+import com.guideon.security.account.domain.MemberVO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberDTO {
+    private MemberType memberType;
+    private String email;
+    private String nickname;
+    private String phone;
+    private String name;
+    private Gender gender;
+    private String birth;
+    private Date createdAt;            // 등록일
+    private Date updatedAt;            // 수정일
+    private List<String> authList;     // 권한 목록 (join 처리 필요)
+
+    // MemberVO에서 DTO 생성 (정적 팩토리 메서드)
+    public static MemberDTO of(MemberVO m) {
+        return MemberDTO.builder()
+                .memberType(m.getMemberType())
+                .email(m.getEmail())
+                .nickname(m.getNickname())
+                .phone(m.getPhone())
+                .name(m.getName())
+                .gender(m.getGender())
+                .birth(String.valueOf(m.getBirth()))
+                .createdAt(m.getCreatedAt())
+                .updatedAt(m.getUpdatedAt())
+                .authList(m.getAuthList().stream()
+                        .map(AuthVO::getAuth)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/member/handler/GenderTypeHandler.java
+++ b/src/main/java/com/guideon/member/handler/GenderTypeHandler.java
@@ -1,0 +1,35 @@
+package com.guideon.member.handler;
+
+import com.guideon.member.domain.Gender;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@MappedTypes(Gender.class)
+public class GenderTypeHandler extends BaseTypeHandler<Gender> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Gender gender, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, gender.getCode());  // enum → DB 값 (MALE → "M")
+    }
+
+    @Override
+    public Gender getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return Gender.fromCode(rs.getString(columnName));  // DB 값 → enum ("F" → FEMALE)
+    }
+
+    @Override
+    public Gender getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return Gender.fromCode(rs.getString(columnIndex));
+    }
+
+    @Override
+    public Gender getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return Gender.fromCode(cs.getString(columnIndex));
+    }
+}

--- a/src/main/java/com/guideon/member/mapper/MemberMapper.java
+++ b/src/main/java/com/guideon/member/mapper/MemberMapper.java
@@ -1,0 +1,8 @@
+package com.guideon.member.mapper;
+
+import com.guideon.security.account.domain.MemberVO;
+import org.apache.ibatis.annotations.Param;
+
+public interface MemberMapper {
+    MemberVO get(@Param("id") Long id, @Param("email") String email);
+}

--- a/src/main/java/com/guideon/member/service/MemberService.java
+++ b/src/main/java/com/guideon/member/service/MemberService.java
@@ -1,0 +1,13 @@
+package com.guideon.member.service;
+
+import com.guideon.member.dto.MemberDTO;
+
+public interface MemberService {
+    /**
+     * id 또는 이메일로 회원 정보 조회
+     * @param id
+     * @param email
+     * @return 회원 dto
+     */
+    MemberDTO get(Long id, String email);    // 두 파라미터 중 하나는 null이어도 됨
+}

--- a/src/main/java/com/guideon/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/guideon/member/service/MemberServiceImpl.java
@@ -1,0 +1,24 @@
+package com.guideon.member.service;
+
+import com.guideon.member.dto.MemberDTO;
+import com.guideon.member.mapper.MemberMapper;
+import com.guideon.security.account.domain.MemberVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+    private final MemberMapper mapper;
+
+    // 회원 정보 조회
+    @Override
+    public MemberDTO get(Long id, String email) {
+        MemberVO member = Optional.ofNullable(mapper.get(id, email))
+                .orElseThrow(NoSuchElementException::new);
+        return MemberDTO.of(member);
+    }
+}

--- a/src/main/java/com/guideon/security/account/domain/AuthVO.java
+++ b/src/main/java/com/guideon/security/account/domain/AuthVO.java
@@ -1,0 +1,19 @@
+package com.guideon.security.account.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthVO implements GrantedAuthority {
+    private Long memberId;
+    private String auth;
+
+    @Override
+    public String getAuthority() {
+        return auth;
+    }
+}

--- a/src/main/java/com/guideon/security/account/domain/CustomUser.java
+++ b/src/main/java/com/guideon/security/account/domain/CustomUser.java
@@ -1,0 +1,28 @@
+package com.guideon.security.account.domain;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+public class CustomUser extends User {
+
+    private MemberVO member;    // 실제 사용자 데이터를 담는 객체
+
+    // 기본 생성자
+    public CustomUser(String username, String password,
+                      Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+    }
+
+    // MemberVO를 받는 생성자 - 실제로 주로 사용
+    public CustomUser(MemberVO vo) {
+        super(vo.getEmail(),           // 사용자 ID
+                vo.getPassword(),
+                vo.getAuthList());          // 권한 목록 (List<AuthVO>)
+
+        this.member = vo;                 // 추가 사용자 정보 저장
+    }
+}

--- a/src/main/java/com/guideon/security/account/domain/MemberVO.java
+++ b/src/main/java/com/guideon/security/account/domain/MemberVO.java
@@ -1,0 +1,31 @@
+package com.guideon.security.account.domain;
+
+import com.guideon.member.domain.Gender;
+import com.guideon.member.domain.MemberType;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberVO {
+    private Long memberId;
+    private MemberType memberType;
+    private String email;
+    private String nickname;
+    private String password;
+    private String name;
+    private String phone;
+    private Gender gender;
+    private LocalDate birth;
+    private Date createdAt;
+    private Date updatedAt;
+
+    @Builder.Default
+    private List<AuthVO> authList = new ArrayList<>();
+}

--- a/src/main/java/com/guideon/security/account/dto/LoginDTO.java
+++ b/src/main/java/com/guideon/security/account/dto/LoginDTO.java
@@ -1,0 +1,33 @@
+package com.guideon.security.account.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginDTO {
+    private String username;
+    private String password;
+
+    /**
+     * HTTP 요청에서 JSON을 LoginDTO 객체로 변환
+     * @param request
+     * @return LoginDTO로 변환된 요청 데이터
+     */
+    public static LoginDTO of(HttpServletRequest request) {
+        ObjectMapper om = new ObjectMapper();
+        try{
+            // RequestBody에 담긴 JSON 문자열을 읽어와 LoginDTO로 역직렬화
+            return om.readValue(request.getInputStream(), LoginDTO.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new BadCredentialsException("username 또는 password가 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/guideon/security/account/dto/UserInfoDTO.java
+++ b/src/main/java/com/guideon/security/account/dto/UserInfoDTO.java
@@ -1,0 +1,43 @@
+package com.guideon.security.account.dto;
+
+import com.guideon.member.domain.MemberType;
+import com.guideon.security.account.domain.AuthVO;
+import com.guideon.security.account.domain.MemberVO;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "사용자 정보 응답 객체")
+public class UserInfoDTO {
+
+    @ApiModelProperty(value = "사용자 이름", example = "홍길동")
+    private String name;
+
+    @ApiModelProperty(value = "사용자 유형", example = "INDIVIDUAL")
+    private MemberType memberType;
+
+    @ApiModelProperty(value = "이메일", example = "user@example.com")
+    private String email;
+
+    @ApiModelProperty(value = "권한 목록", example = "[\"ROLE_USER\"]")
+    private List<String> roles;
+
+    public static UserInfoDTO of(MemberVO member) {
+        return new UserInfoDTO(
+                member.getName(),
+                member.getMemberType(),
+                member.getEmail(),
+                member.getAuthList().stream()
+                        .map(AuthVO::getAuth)
+                        .toList()
+        );
+    }
+}
+

--- a/src/main/java/com/guideon/security/config/SecurityConfig.java
+++ b/src/main/java/com/guideon/security/config/SecurityConfig.java
@@ -1,24 +1,126 @@
 package com.guideon.security.config;
 
+import com.guideon.security.filter.AuthenticationErrorFilter;
+import com.guideon.security.filter.JwtAuthenticationFilter;
+import com.guideon.security.filter.JwtUsernamePasswordAuthenticationFilter;
+import com.guideon.security.handler.CustomAccessDeniedHandler;
+import com.guideon.security.handler.CustomAuthenticationEntryPoint;
+import com.guideon.security.policy.AccessPolicy;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebSecurity
 @Slf4j
+@ComponentScan(basePackages = {"com.guideon.security"})
+@RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final UserDetailsService userDetailsService;
+    // JWT 인증 필터
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    // 인증 예외처리 필터
+    private final AuthenticationErrorFilter authenticationErrorFilter;
+
+    // 401/403 에러 처리 핸들러
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Autowired
+    private JwtUsernamePasswordAuthenticationFilter jwtUsernamePasswordAuthenticationFilter;
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        // UserDetailsService와 PasswordEncoder 설정
+        auth.userDetailsService(userDetailsService)  // 커스텀 서비스 사용
+                .passwordEncoder(passwordEncoder()); // BCrypt 암호화 사용
+    }
+
+    /**
+     * CORS 설정 - 모든 도메인 허용
+     */
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowCredentials(true);               // 인증 정보 포함 허용
+        config.addAllowedOriginPattern("*");            // 모든 도메인 허용
+        config.addAllowedHeader("*");                   // 모든 헤더 허용
+        config.addAllowedMethod("*");                   // 모든 HTTP 메서드 허용
+
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+
+    // 문자셋 필터 메서드
+    public CharacterEncodingFilter encodingFilter() {
+        CharacterEncodingFilter encodingFilter = new CharacterEncodingFilter();
+        encodingFilter.setEncoding("UTF-8");           // UTF-8 인코딩 설정
+        encodingFilter.setForceEncoding(true);         // 강제 인코딩 적용
+        return encodingFilter;
+    }
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        // 기본 설정으로 시작 - 모든 요청에 인증 필요
-        http.authorizeRequests() //  요청 권한 설정
-                .anyRequest().authenticated() // 모든 요청에 인증 필요
-                .and()
-                .formLogin() // 기본 로그인 폼 활성화
-                .and()
-                .logout(); // 로그아웃 기능 활성화
+        http.addFilterBefore(encodingFilter(), CsrfFilter.class)
+                .addFilterBefore(authenticationErrorFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtUsernamePasswordAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        //예외 처리 설정
+        http.exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint)
+                .accessDeniedHandler(accessDeniedHandler);
+
+        //  HTTP 보안 설정
+        http.httpBasic().disable()      // 기본 HTTP 인증 비활성화
+                .csrf().disable()           // CSRF 보호 비활성화 (REST API에서는 불필요)
+                .formLogin().disable()      // 폼 로그인 비활성화 (JSON 기반 API 사용)
+                .sessionManagement()        // 세션 관리 설정
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);  // 무상태 모드
+
+        http.cors();
+
+        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http.authorizeRequests();
+        // permitAll 경로 등록
+        for (AccessPolicy.AccessRule rule : AccessPolicy.PERMIT_ALL) {
+            if (rule.method != null) {
+                registry.antMatchers(rule.method, rule.uriPattern).permitAll();
+            } else {
+                registry.antMatchers(rule.uriPattern).permitAll();
+            }
+        }
+        registry.anyRequest().authenticated(); // 나머지 인증 필요
     }
 }

--- a/src/main/java/com/guideon/security/controller/AuthController.java
+++ b/src/main/java/com/guideon/security/controller/AuthController.java
@@ -1,0 +1,96 @@
+package com.guideon.security.controller;
+
+import com.guideon.common.redis.RedisKeyUtil;
+import com.guideon.common.redis.RedisService;
+import com.guideon.member.service.MemberService;
+import com.guideon.security.account.domain.MemberVO;
+import com.guideon.security.account.dto.UserInfoDTO;
+import com.guideon.security.util.CookieUtil;
+import com.guideon.security.util.JwtConstants;
+import com.guideon.security.util.JwtProcessor;
+import com.guideon.security.util.LoginUserProvider;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Api(tags = "인증 관리 API", description = "JWT 토큰 기반 인증, 로그아웃, 토큰 재발급")
+public class AuthController {
+
+    private final RedisService redisService;
+    private final JwtProcessor jwtProcessor;
+    private final MemberService memberService;
+    private final LoginUserProvider loginUserProvider;
+
+    @PostMapping("/logout")
+    @ApiOperation(value = "로그아웃", notes = "Access Token을 블랙리스트에 등록하고 Refresh Token을 삭제.")
+    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+        // Access Token blacklist 등록
+        String token = jwtProcessor.extractAccessToken(request);
+        if (StringUtils.hasText(token) && jwtProcessor.validateAccessToken(token)) {
+            long remaining = jwtProcessor.getRemainingExpiration(token);
+            redisService.blacklistToken(token, remaining);
+            CookieUtil.deleteCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE_NAME, "/");
+        }
+
+        // refresh 토큰 삭제
+        String refreshToken = jwtProcessor.extractRefreshToken(request);
+        if (StringUtils.hasText(refreshToken) && jwtProcessor.validateRefreshToken(refreshToken)) {
+            Long memberId = jwtProcessor.getMemberId(refreshToken);
+            redisService.delete(RedisKeyUtil.refreshToken(memberId));
+            CookieUtil.deleteCookie(response, JwtConstants.REFRESH_TOKEN_COOKIE_NAME, "/api/auth/reissue");
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    @ApiOperation(value = "현재 로그인 사용자 정보 조회", notes = "현재 로그인된 사용자의 기본 정보를 반환.")
+    public ResponseEntity<UserInfoDTO> getMe() {
+        MemberVO member = loginUserProvider.getLoginUser();
+        if (member == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return ResponseEntity.ok(UserInfoDTO.of(member));
+    }
+
+    @PostMapping("/reissue")
+    @ApiOperation(value = "Access Token 재발급", notes = "Refresh Token을 사용하여 새로운 Access Token을 발급.")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtProcessor.extractRefreshToken(request); // 쿠키에서 추출
+
+        if (!StringUtils.hasText(refreshToken) || !jwtProcessor.validateRefreshToken(refreshToken)) {
+            throw new IllegalStateException("유효하지 않은 Refresh Token입니다");
+        }
+
+        Long memberId = jwtProcessor.getMemberId(refreshToken);
+        String redisKey = RedisKeyUtil.refreshToken(memberId);
+        String savedRefreshToken = redisService.get(redisKey);
+
+        // 탈취 감지: 저장된 토큰과 일치하지 않으면 로그아웃 처리
+        if (!refreshToken.equals(savedRefreshToken)) {
+            redisService.delete(redisKey); // 탈취된 토큰 무효화
+            throw new IllegalStateException("Refresh Token 정보가 일치하지 않습니다");
+        }
+
+        String email = memberService.get(memberId, null).getEmail();
+        if (!StringUtils.hasText(email)) {
+            throw new IllegalStateException("존재하지 않는 사용자입니다");
+        }
+        String newAccessToken = jwtProcessor.generateAccessToken(memberId, email);
+        CookieUtil.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE_NAME, newAccessToken, JwtConstants.ACCESS_TOKEN_EXP_SECONDS, "/");
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/guideon/security/filter/AuthenticationErrorFilter.java
+++ b/src/main/java/com/guideon/security/filter/AuthenticationErrorFilter.java
@@ -1,0 +1,33 @@
+package com.guideon.security.filter;
+
+import com.guideon.security.util.JsonResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class AuthenticationErrorFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            super.doFilter(request, response, filterChain);
+        } catch (ExpiredJwtException e) {
+            JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "토큰의 유효시간이 지났습니다.");
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
+            JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, e.getMessage());
+        } catch (ServletException e) {
+            JsonResponse.sendError(response, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/guideon/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/guideon/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package com.guideon.security.filter;
+
+import com.guideon.common.redis.RedisService;
+import com.guideon.security.policy.AccessPolicy;
+import com.guideon.security.util.JsonResponse;
+import com.guideon.security.util.JwtProcessor;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProcessor jwtProcessor;
+    private final UserDetailsService userDetailsService;
+    private final RedisService redisService;
+
+    private Authentication getAuthentication(String accessToken) {
+        String username = jwtProcessor.getEmail(accessToken);
+        UserDetails principal = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+    }
+
+    private boolean isPermitted(HttpServletRequest request) {
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+        String requestUri = request.getRequestURI();
+        String method = request.getMethod();
+
+        return AccessPolicy.PERMIT_ALL.stream().anyMatch(rule -> {
+            boolean methodMatch = (rule.method == null || rule.method.name().equalsIgnoreCase(method));
+            boolean uriMatch = pathMatcher.match(rule.uriPattern, requestUri);
+            return methodMatch && uriMatch;
+        });
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 인증 우회 경로 처리
+        if (isPermitted(request)) {
+            super.doFilter(request, response, filterChain);
+            return;
+        }
+
+        String accessToken = jwtProcessor.extractAccessToken(request);
+        String refreshToken = jwtProcessor.extractRefreshToken(request);
+
+        // accessToken 없고 refreshToken만 있을 때 → 재발급 유도
+        if (!StringUtils.hasText(accessToken) && StringUtils.hasText(refreshToken)) {
+            JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "ACCESS_TOKEN_EXPIRED");
+            return;
+        }
+        // accessToken이 존재할 때만 인증 처리
+        if (StringUtils.hasText(accessToken)) {
+            // 로그아웃(차단)된 토큰인지 Redis에서 검사
+            if (redisService.isBlacklisted(accessToken)) {
+                JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "BLACKLISTED_TOKEN");
+                return;
+            }
+
+            try {
+                // 토큰에서 사용자 정보 추출 및 Authentication 객체 구성 후 SecurityContext에 저장
+                Authentication authentication = getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (ExpiredJwtException e) {
+                log.warn("Access Token 만료: {}", e.getMessage());
+                JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "ACCESS_TOKEN_EXPIRED");
+                return;
+            } catch (Exception e) {
+                log.error("JWT 인증 실패: {}", e.getMessage());
+                JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "INVALID_ACCESS_TOKEN");
+                return;
+            }
+        }
+        super.doFilter(request, response, filterChain);
+    }
+}

--- a/src/main/java/com/guideon/security/filter/JwtUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/guideon/security/filter/JwtUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.guideon.security.filter;
+
+import com.guideon.security.account.dto.LoginDTO;
+import com.guideon.security.handler.LoginFailureHandler;
+import com.guideon.security.handler.LoginSuccessHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@Component
+public class JwtUsernamePasswordAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    // 필터 생성자
+    public JwtUsernamePasswordAuthenticationFilter(
+            AuthenticationManager authenticationManager,    // SecurityConfig 생성 후 Bean 등록
+            LoginSuccessHandler loginSuccessHandler,
+            LoginFailureHandler loginFailureHandler) {
+
+        super(authenticationManager);
+        setFilterProcessesUrl("/api/auth/login");                    // POST 로그인 요청 URL
+        setAuthenticationSuccessHandler(loginSuccessHandler);        // 성공 핸들러 등록
+        setAuthenticationFailureHandler(loginFailureHandler);        // 실패 핸들러 등록
+    }
+
+
+    // 인증 시도 메서드
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+
+        // 1. 요청 BODY의 JSON에서 username, password 추출
+        LoginDTO login = LoginDTO.of(request);
+
+        // 2. 인증 토큰(UsernamePasswordAuthenticationToken) 구성
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(login.getUsername(), login.getPassword());
+
+        // 3. AuthenticationManager에게 인증 요청
+        return getAuthenticationManager().authenticate(authenticationToken);
+    }
+
+}

--- a/src/main/java/com/guideon/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/guideon/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.guideon.security.handler;
+
+import com.guideon.security.util.JsonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+
+        log.error("========== 인가 에러 ============");
+        JsonResponse.sendError(
+                response,
+                HttpStatus.FORBIDDEN,
+                "권한이 부족합니다."
+        );
+    }
+}

--- a/src/main/java/com/guideon/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/guideon/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.guideon.security.handler;
+
+import com.guideon.security.util.JsonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+
+        log.error("========== 인증 에러 ============");
+        JsonResponse.sendError(
+                response,
+                HttpStatus.UNAUTHORIZED,
+                authException.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/guideon/security/handler/LoginFailureHandler.java
+++ b/src/main/java/com/guideon/security/handler/LoginFailureHandler.java
@@ -1,0 +1,24 @@
+package com.guideon.security.handler;
+
+import com.guideon.security.util.JsonResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+
+        // UNAUTHORIZED 상태와 에러 메시지로 응답
+        JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/guideon/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/guideon/security/handler/LoginSuccessHandler.java
@@ -1,0 +1,33 @@
+package com.guideon.security.handler;
+
+import com.guideon.security.account.domain.CustomUser;
+import com.guideon.security.account.dto.UserInfoDTO;
+import com.guideon.security.service.AuthTokenService;
+import com.guideon.security.util.JsonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+    private final AuthTokenService authTokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        // 인증 결과에서 사용자 정보 추출
+        CustomUser user = (CustomUser) authentication.getPrincipal();
+
+        authTokenService.issueTokenAndSetCookie(response, user.getMember());
+        JsonResponse.send(response, UserInfoDTO.of(user.getMember()));
+    }
+}

--- a/src/main/java/com/guideon/security/policy/AccessPolicy.java
+++ b/src/main/java/com/guideon/security/policy/AccessPolicy.java
@@ -17,17 +17,6 @@ public class AccessPolicy {
             new AccessRule(null, "/webjars/**", null),
             new AccessRule(null, "/webjars/springfox-swagger-ui/**", null),
 
-            // 금융 API 공개 GET
-            new AccessRule(HttpMethod.GET, "/api/news/**", null),   // 경제뉴스 API 공개
-            new AccessRule(HttpMethod.GET, "/api/gold/**", null),   // 금융차트 금 API 공개
-            new AccessRule(HttpMethod.GET, "/api/stocks/**", null), // 금융차트 주식 API 공개
-            new AccessRule(HttpMethod.POST, "/api/stocks/**", null), // 금융차트 주식 API 공개
-            new AccessRule(HttpMethod.GET, "/api/upbit/**", null),  // 금융차트 가상화페 API 공개 get 방식
-            new AccessRule(HttpMethod.POST, "/api/upbit/**", null),  // 금융차트 가상화페 API 공개 post 방식
-            new AccessRule(HttpMethod.GET, "/api/exchange/**", null),   // 금융차트 외환 API 공개
-            new AccessRule(HttpMethod.GET, "/api/health/**", null),     // 금융차트  API 연결여부 공개
-            new AccessRule(HttpMethod.GET, "/api/terms/**", null),      // 금융용어  API  공개
-
             // 회원 관련
             new AccessRule(HttpMethod.POST, "/api/member", null), // 회원가입
             new AccessRule(HttpMethod.GET, "/api/member/exist/email/**", null), // 이메일 중복 체크
@@ -37,13 +26,7 @@ public class AccessPolicy {
 
             // 인증 토큰
             new AccessRule(HttpMethod.POST, "/api/auth/reissue", null), // 토큰 재발급
-            new AccessRule(HttpMethod.POST, "/api/auth/logout", null),  // 로그아웃
-
-            // 소셜 로그인
-            new AccessRule(null, "/login/**", null),
-            new AccessRule(null, "/oauth2/**", null),
-            new AccessRule(null, "/login/oauth2/**", null),
-            new AccessRule(null, "/api/gemini/**", null)
+            new AccessRule(HttpMethod.POST, "/api/auth/logout", null)   // 로그아웃
     );
 
     // 인증 필요 (명시적으로 지정 필요 시 사용)

--- a/src/main/java/com/guideon/security/policy/AccessPolicy.java
+++ b/src/main/java/com/guideon/security/policy/AccessPolicy.java
@@ -1,0 +1,70 @@
+package com.guideon.security.policy;
+
+import org.springframework.http.HttpMethod;
+
+import java.util.List;
+
+public class AccessPolicy {
+
+    // permitAll 리스트
+    public static final List<AccessRule> PERMIT_ALL = List.of(
+            // Swagger UI 관련 경로 추가 (가장 위에 배치)
+            new AccessRule(null, "/swagger-ui.html", null),
+            new AccessRule(null, "/swagger-ui/**", null),
+            new AccessRule(null, "/swagger-resources/**", null),
+            new AccessRule(null, "/v2/api-docs", null),
+            new AccessRule(null, "/v2/api-docs/**", null),
+            new AccessRule(null, "/webjars/**", null),
+            new AccessRule(null, "/webjars/springfox-swagger-ui/**", null),
+
+            // 금융 API 공개 GET
+            new AccessRule(HttpMethod.GET, "/api/news/**", null),   // 경제뉴스 API 공개
+            new AccessRule(HttpMethod.GET, "/api/gold/**", null),   // 금융차트 금 API 공개
+            new AccessRule(HttpMethod.GET, "/api/stocks/**", null), // 금융차트 주식 API 공개
+            new AccessRule(HttpMethod.POST, "/api/stocks/**", null), // 금융차트 주식 API 공개
+            new AccessRule(HttpMethod.GET, "/api/upbit/**", null),  // 금융차트 가상화페 API 공개 get 방식
+            new AccessRule(HttpMethod.POST, "/api/upbit/**", null),  // 금융차트 가상화페 API 공개 post 방식
+            new AccessRule(HttpMethod.GET, "/api/exchange/**", null),   // 금융차트 외환 API 공개
+            new AccessRule(HttpMethod.GET, "/api/health/**", null),     // 금융차트  API 연결여부 공개
+            new AccessRule(HttpMethod.GET, "/api/terms/**", null),      // 금융용어  API  공개
+
+            // 회원 관련
+            new AccessRule(HttpMethod.POST, "/api/member", null), // 회원가입
+            new AccessRule(HttpMethod.GET, "/api/member/exist/email/**", null), // 이메일 중복 체크
+            new AccessRule(HttpMethod.POST, "/api/verification/**", null), // 이메일/전화번호 인증
+            new AccessRule(HttpMethod.POST, "/api/member/find/**", null), // 아이디 찾기
+            new AccessRule(HttpMethod.POST, "/api/member/password/reset", null), // 비밀번호 재설정
+
+            // 인증 토큰
+            new AccessRule(HttpMethod.POST, "/api/auth/reissue", null), // 토큰 재발급
+            new AccessRule(HttpMethod.POST, "/api/auth/logout", null),  // 로그아웃
+
+            // 소셜 로그인
+            new AccessRule(null, "/login/**", null),
+            new AccessRule(null, "/oauth2/**", null),
+            new AccessRule(null, "/login/oauth2/**", null),
+            new AccessRule(null, "/api/gemini/**", null)
+    );
+
+    // 인증 필요 (명시적으로 지정 필요 시 사용)
+//    public static final List<AccessRule> AUTHENTICATED = List.of(
+//            new AccessRule(HttpMethod.POST, "/api/member/update", "AUTHENTICATED")
+//    );
+
+    // 역할 구분 필요시 사용 (참고용)
+//    public static final List<AccessRule> ADMIN_ONLY = List.of(
+//            new AccessRule(HttpMethod.GET, "/api/admin/**", "ROLE_ADMIN")
+//    );
+
+    public static class AccessRule {
+        public final HttpMethod method;
+        public final String uriPattern;
+        public final String role; // null: permitAll, "AUTHENTICATED", "ROLE_ADMIN"
+
+        public AccessRule(HttpMethod method, String uriPattern, String role) {
+            this.method = method;
+            this.uriPattern = uriPattern;
+            this.role = role;
+        }
+    }
+}

--- a/src/main/java/com/guideon/security/service/AuthTokenService.java
+++ b/src/main/java/com/guideon/security/service/AuthTokenService.java
@@ -1,0 +1,37 @@
+package com.guideon.security.service;
+
+import com.guideon.common.redis.RedisKeyUtil;
+import com.guideon.common.redis.RedisService;
+import com.guideon.security.account.domain.MemberVO;
+import com.guideon.security.util.CookieUtil;
+import com.guideon.security.util.JwtConstants;
+import com.guideon.security.util.JwtProcessor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Service
+@RequiredArgsConstructor
+public class AuthTokenService {
+    public static final int REFRESH_TOKEN_EXP_MINUTES = JwtConstants.REFRESH_TOKEN_EXP_SECONDS / 60;
+
+    private final JwtProcessor jwtProcessor;
+    private final RedisService redisService;
+
+    // 토큰 발급 후 HttpOnly 쿠키에 저장
+    public void issueTokenAndSetCookie(HttpServletResponse response, MemberVO member) {
+        String email = member.getEmail();
+        Long memberId = member.getMemberId();
+
+        // JWT 토큰 생성
+        String access = jwtProcessor.generateAccessToken(memberId, email);
+        String refresh = jwtProcessor.generateRefreshToken(memberId);
+
+        // Redis에 저장 (key = "RT:<memberId>", value = token)
+        redisService.set(RedisKeyUtil.refreshToken(memberId), refresh,  REFRESH_TOKEN_EXP_MINUTES);
+
+        CookieUtil.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE_NAME, access, JwtConstants.ACCESS_TOKEN_EXP_SECONDS, "/");
+        CookieUtil.addCookie(response, JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refresh, JwtConstants.REFRESH_TOKEN_EXP_SECONDS, "/api/auth/reissue");
+    }
+}

--- a/src/main/java/com/guideon/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/guideon/security/service/CustomUserDetailsService.java
@@ -1,0 +1,38 @@
+package com.guideon.security.service;
+
+import com.guideon.member.mapper.MemberMapper;
+import com.guideon.security.account.domain.CustomUser;
+import com.guideon.security.account.domain.MemberVO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberMapper mapper;  // MyBatis 매퍼 주입
+
+    // loadUserByUsername() : 사용자 이름(username)을 이용해 사용자 정보를 조회하는 서비스
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info("사용자 정보 조회: {}", username);
+
+        // 데이터베이스에서 사용자 정보 조회
+        MemberVO vo = mapper.get(null, username);
+
+        // 사용자가 존재하지 않는 경우 예외 발생
+        if(vo == null) {
+            throw new UsernameNotFoundException(username + "은 없는 아이디입니다.");
+        }
+
+        log.info("조회된 사용자: {}", vo.getEmail());
+
+        // CustomUser 객체로 변환하여 반환
+        return new CustomUser(vo);
+    }
+}

--- a/src/main/java/com/guideon/security/util/CookieUtil.java
+++ b/src/main/java/com/guideon/security/util/CookieUtil.java
@@ -1,0 +1,40 @@
+package com.guideon.security.util;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+
+public class CookieUtil {
+
+    // 쿠키 생성 및 응답에 추가
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge,  String path) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setMaxAge(maxAge);             // 초 단위: 60 * 60 * 24 = 1일
+        cookie.setHttpOnly(true);             // JS 접근 불가
+        cookie.setSecure(false);             // HTTPS 전용X (로컬 테스트는 false 허용으로 수정 필요!!!)
+        cookie.setPath(path);                 // 모든 경로에 전송
+
+        response.addCookie(cookie);
+    }
+
+    // 쿠키 삭제 (만료시간 0)
+    public static void deleteCookie(HttpServletResponse response, String name, String path) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setMaxAge(0);                  // 즉시 만료
+        cookie.setPath(path);
+        response.addCookie(cookie);
+    }
+
+    // 쿠키 값 조회
+    public static String getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElse(null);
+    }
+}
+

--- a/src/main/java/com/guideon/security/util/JsonResponse.java
+++ b/src/main/java/com/guideon/security/util/JsonResponse.java
@@ -1,0 +1,28 @@
+package com.guideon.security.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+
+public class JsonResponse {
+    // 제네릭을 사용한 JSON 응답 처리
+    public static <T> void send(HttpServletResponse response, T result) throws IOException {
+        ObjectMapper om = new ObjectMapper();
+        response.setContentType("application/json;charset=UTF-8");
+        Writer out = response.getWriter();
+        out.write(om.writeValueAsString(result));  // 객체를 JSON 문자열로 직렬화
+        out.flush();
+    }
+
+    // 에러 응답 처리
+    public static void sendError(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json;charset=UTF-8");
+        Writer out = response.getWriter();
+        out.write(message);
+        out.flush();
+    }
+}

--- a/src/main/java/com/guideon/security/util/JwtConstants.java
+++ b/src/main/java/com/guideon/security/util/JwtConstants.java
@@ -1,0 +1,12 @@
+package com.guideon.security.util;
+
+public final class JwtConstants {
+    private JwtConstants() {} // 인스턴스화 방지
+
+    // 단위: 초 (쿠키 저장 등)
+    public static final int ACCESS_TOKEN_EXP_SECONDS = 60 * 15; // 15분
+    public static final int REFRESH_TOKEN_EXP_SECONDS = 60 * 60 * 24 * 7; // 7일
+    // 쿠키 name
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+}

--- a/src/main/java/com/guideon/security/util/JwtKeyManager.java
+++ b/src/main/java/com/guideon/security/util/JwtKeyManager.java
@@ -1,0 +1,34 @@
+package com.guideon.security.util;
+
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+import javax.annotation.PostConstruct;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+
+@Component
+@PropertySource({"classpath:/application.properties"})
+public class JwtKeyManager {
+
+    @Value("${jwt.secret-key}")
+    private String secretKeyString;
+
+    @Getter
+    private Key key;
+
+    @PostConstruct
+    public void initKey() {
+        if (secretKeyString.length() < 32) {
+            throw new IllegalArgumentException("JWT Secret Key는 최소 32자 이상이어야 합니다.");
+        }
+
+        this.key = Keys.hmacShaKeyFor(
+                secretKeyString.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+}

--- a/src/main/java/com/guideon/security/util/JwtProcessor.java
+++ b/src/main/java/com/guideon/security/util/JwtProcessor.java
@@ -1,0 +1,198 @@
+package com.guideon.security.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProcessor {
+    static private final long ACCESS_TOKEN_VALID_MILLISECOND = 1000L * JwtConstants.ACCESS_TOKEN_EXP_SECONDS; // 15분
+    static private final long REFRESH_TOKEN_VALID_MILLISECOND = 1000L * JwtConstants.REFRESH_TOKEN_EXP_SECONDS; // 7일
+
+    private final JwtKeyManager jwtKeyManager;
+
+    private Key getKey() {
+        return jwtKeyManager.getKey();
+    }
+
+    public String generateAccessToken(Long memberId, String username) {
+        return generateTokenWithClaims(String.valueOf(memberId), username, ACCESS_TOKEN_VALID_MILLISECOND);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        return generateToken(String.valueOf(memberId), REFRESH_TOKEN_VALID_MILLISECOND);
+    }
+
+    /* ***** 토큰 생성 메서드 ***** */
+    /**
+     * JWT 토큰 생성
+     * @param subject 사용자 식별자 (member_id 사용)
+     * @return 생성된 JWT 토큰 문자열
+     */
+    public String generateToken(String subject, Long tokenValidTime) {
+        return Jwts.builder()
+                .setSubject(subject)                    // 사용자 식별자
+                .setIssuedAt(new Date())               // 발급 시간
+                .setExpiration(new Date(new Date().getTime() + tokenValidTime))  // 만료 시간
+                .signWith(getKey())                     // 서명
+                .compact();                            // 문자열 생성
+    }
+
+    /**
+     * 권한 정보를 포함한 토큰 생성
+     */
+    public String generateTokenWithRole(String subject, String role) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(new Date().getTime() + ACCESS_TOKEN_VALID_MILLISECOND))
+                .claim("role", role)                   // 권한 정보 추가
+                .signWith(getKey())
+                .compact();
+    }
+
+    /* ***** 토큰 생성 메서드 ***** */
+    /**
+     * JWT 토큰 생성
+     * @param subject 사용자 식별자 (member_id)
+     * @param email 사용자 로그인 ID(이메일)
+     * @return 생성된 JWT 토큰 문자열
+     */
+    public String generateTokenWithClaims(String subject, String email, long tokenValidTime) {
+        return Jwts.builder()
+                .setSubject(subject)               // memberId
+                .claim("email", email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + tokenValidTime))
+                .signWith(getKey())
+                .compact();
+    }
+
+    /* ***** 토큰 검증 및 정보 추출 ***** */
+
+    public String getSubject(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    /**
+     * JWT Subject(username) 추출
+     * @param token JWT 토큰
+     * @return 사용자명
+     * @throws JwtException 토큰 해석 불가 시 예외 발생
+     */
+    public Long getMemberId(String token) {
+        String id = getSubject(token);
+        return Long.parseLong(id);
+    }
+
+    /**
+     * JWT Subject(role) 추출
+     * @param token JWT 토큰
+     * @return 사용자명
+     * @throws JwtException 토큰 해석 불가 시 예외 발생
+     */
+    public String getRole(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+    }
+
+    /**
+     * JWT Member ID 추출
+     * @param token JWT 토큰
+     * @return email
+     * @throws JwtException 토큰 해석 불가 시 예외 발생
+     */
+    public String getEmail(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("email", String.class);  // email claim 추출
+    }
+
+    public String getProvider(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("provider", String.class);
+    }
+
+    /**
+     * Access 토큰 검증 (유효 기간 및 서명 검증)
+     * @param token Access 토큰
+     * @return 검증 결과 (true: 유효, false: 무효)
+     */
+    public boolean validateAccessToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(getKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.warn("Access Token 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(getKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            log.warn("Refresh Token 검증 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Refresh Token 추출: 쿠키 → 헤더 순서
+     * @param request HttpServletRequest
+     * @return Refresh Token 문자열 (없으면 null)
+     */
+    public String extractRefreshToken(HttpServletRequest request) {
+        return CookieUtil.getCookieValue(request, JwtConstants.REFRESH_TOKEN_COOKIE_NAME);
+    }
+
+    public String extractAccessToken(HttpServletRequest request) {
+        return CookieUtil.getCookieValue(request, JwtConstants.ACCESS_TOKEN_COOKIE_NAME);
+    }
+
+    public long getRemainingExpiration(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getExpiration().getTime() - System.currentTimeMillis();
+    }
+
+}
+

--- a/src/main/java/com/guideon/security/util/LoginUserProvider.java
+++ b/src/main/java/com/guideon/security/util/LoginUserProvider.java
@@ -1,0 +1,32 @@
+package com.guideon.security.util;
+
+import com.guideon.security.account.domain.CustomUser;
+import com.guideon.security.account.domain.MemberVO;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoginUserProvider {
+    public MemberVO getLoginUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) return null;
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUser) {
+            return ((CustomUser) principal).getMember();
+        }
+
+        return null;
+    }
+
+    public Long getLoginMemberId() {
+        MemberVO user = getLoginUser();
+        return user != null ? user.getMemberId() : null;
+    }
+
+    public String getLoginEmail() {
+        MemberVO user = getLoginUser();
+        return user != null ? user.getEmail() : null;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.redis.port=6379
 spring.redis.password=${REDIS_PASSWORD}
 spring.redis.timeout-ms=3000
 spring.redis.ssl=false
+
+jwt.secret-key=${JWT_SECRET}

--- a/src/main/resources/com/guideon/member/mapper/MemberMapper.xml
+++ b/src/main/resources/com/guideon/member/mapper/MemberMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- 실제 사용 시 네임스페이스를 인터페이스 경로로 변경 -->
+<mapper namespace="com.guideon.member.mapper.MemberMapper">
+    <resultMap id="authMap" type="AuthVO">
+        <result property="memberId" column="member_id" />
+        <result property="auth" column="auth" />
+    </resultMap>
+    <resultMap id="memberMap" type="MemberVO">
+        <id property="memberId" column="member_id" />
+        <result property="memberType" column="member_type" />
+        <result property="nickname" column="nickname" />
+        <result property="email" column="email" />
+        <result property="password" column="password" />
+        <result property="name" column="name" />
+        <result property="phone" column="phone" />
+        <result property="gender" column="gender" />
+        <result property="birth" column="birth" />
+        <result property="createdAt" column="created_at" />
+        <result property="updatedAt" column="updated_at" />
+        <collection property="authList" resultMap="authMap" />
+    </resultMap>
+
+    <!-- 회원 정보 조회 (LEFT JOIN으로 권한 정보 포함) -->
+    <select id="get" resultMap="memberMap">
+        SELECT m.member_id, member_type, nickname, email, password, name, phone, gender, birth, created_at, updated_at, auth
+        FROM
+            member m
+                LEFT OUTER JOIN member_auth a
+                                ON m.member_id = a.member_id
+        WHERE m.member_id = #{id} OR m.email = #{email}
+            LIMIT 1
+    </select>
+</mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -7,4 +7,13 @@
     <settings>
         <setting name="mapUnderscoreToCamelCase" value="true"/>
     </settings>
+
+    <typeAliases>
+        <package name="com.guideon.security.account.domain"/>
+    </typeAliases>
+
+    <typeHandlers>
+        <typeHandler handler="com.guideon.member.handler.GenderTypeHandler"
+                    javaType="com.guideon.member.domain.Gender"/>
+    </typeHandlers>
 </configuration>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

- Spring Security 기반 일반 로그인/로그아웃 + 토큰 재발급 플로우 구현
- JWT Access/Refresh 발급, HttpOnly 쿠키 저장, 로그아웃 시 쿠키 삭제 + Redis 블랙리스트 적용

## 📖 작업 내용 

- Security 설정
- JWT 인증 필터
- 로그인/재발급/로그아웃 API
   - POST /api/auth/login : { username, password } → Access/Refresh 발급 후 HttpOnly 쿠키 저장
   - POST /api/auth/reissue : Refresh(쿠키) 검증 → 신규 Access 발급
   - POST /api/auth/logout : Access 블랙리스트 등록(남은 TTL로) + RT:{memberId} 삭제 + 쿠키 만료
- 토큰·쿠키 정책
- Redis 키 컨벤션

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #3
