### PR TITLE
Feat : 사용자 질문 정보 저장 및 응답 기반 맞춤 정책자금 목록 조회 API 구현

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,6 @@ REDIS_PASSWORD=
 # JWT 관련
 JWT_SECRET=TestSecretKey_AtLeast_32_Characters_Long_123456
 
-DB_URL=jdbc:log4jdbc:mysql://localhost:3306/guideon_db
+DB_URL=jdbc:log4jdbc:mysql://localhost:3306/guideon
 DB_USERNAME=root
-DB_PASSWORD=whwkahd0226
+DB_PASSWORD=1234

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ bin/
 .DS_Store
 
 ### env file ###
-src/main/resources/.env
+.env
 
 # 민감 정보 보호
 src/main/resources/application.properties

--- a/src/main/java/com/guideon/community/mapper/MemberLookupMapper.java
+++ b/src/main/java/com/guideon/community/mapper/MemberLookupMapper.java
@@ -1,0 +1,9 @@
+package com.guideon.community.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface MemberLookupMapper {
+    Long findMemberIdByEmail(@Param("email") String email);
+}

--- a/src/main/java/com/guideon/config/RootConfig.java
+++ b/src/main/java/com/guideon/config/RootConfig.java
@@ -21,11 +21,13 @@ import javax.sql.DataSource;
 @PropertySource({"classpath:/application.properties"})
 @MapperScan(basePackages = {
         "com.guideon.member.mapper",
+        "com.guideon.document.mapper",
         "com.guideon.community.mapper",
 })
 @ComponentScan(basePackages = {
         "com.guideon.member.service",
         "com.guideon.common.redis",
+        "com.guideon.document.service",
         "com.guideon.community",      // 서비스/컨트롤러/예외
         "com.guideon.common"          // 공통 응답/예외/스토리지
 })

--- a/src/main/java/com/guideon/config/ServletConfig.java
+++ b/src/main/java/com/guideon/config/ServletConfig.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @ComponentScan(basePackages = {
         "com.guideon.exception",
         "com.guideon.security.controller",
+        "com.guideon.document.controller",
         "com.guideon.community.controller",
         "com.guideon.common.exception"   // GlobalExceptionHandler
 })

--- a/src/main/java/com/guideon/document/controller/PolicyController.java
+++ b/src/main/java/com/guideon/document/controller/PolicyController.java
@@ -1,0 +1,69 @@
+package com.guideon.document.controller;
+
+import com.guideon.document.dto.PolicyDTO;
+import com.guideon.document.service.PolicyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/policy")
+@Log4j2
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    /**
+     * 맞춤형 정책자금 목록 조회
+     * 1. 소상공인 자격 판별
+     * 2. 자격 충족 시 정책자금 필터링 후 목록 반환
+     * 3. 자격 미달 시 소상공인 아님 메시지 반환
+     */
+    @GetMapping("/{businessId}")
+    public ResponseEntity<Map<String, Object>> getPolicies(@PathVariable Long businessId) {
+        try {
+            log.info("정책자금 조회 요청: businessId={}", businessId);
+
+            // 1. 소상공인 자격 판별
+            if (!policyService.isSmallBusiness(businessId)) {
+                Map<String, Object> response = new HashMap<>();
+                response.put("success", false);
+                response.put("isSmallBusiness", false);
+                response.put("message", "소상공인 자격 요건에 해당하지 않습니다.");
+
+                return ResponseEntity.ok(response);
+            }
+
+            // 2. 정책자금 필터링
+            List<PolicyDTO> eligiblePolicies = policyService.filterEligiblePolicies(businessId);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("isSmallBusiness", true);
+            response.put("eligiblePolicies", eligiblePolicies);
+            response.put("totalCount", eligiblePolicies.size());
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", e.getMessage()
+            ));
+
+        } catch (Exception e) {
+            log.error("정책자금 조회 오류: businessId={}", businessId, e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "success", false,
+                    "message", "서버 오류가 발생했습니다."
+            ));
+        }
+    }
+}

--- a/src/main/java/com/guideon/document/controller/SurveyController.java
+++ b/src/main/java/com/guideon/document/controller/SurveyController.java
@@ -1,0 +1,94 @@
+package com.guideon.document.controller;
+
+import com.guideon.common.redis.RedisService;
+import com.guideon.document.dto.BusinessInfoDTO;
+import com.guideon.document.dto.UserSurveyRequest;
+import com.guideon.document.service.SurveyService;
+import com.guideon.security.util.LoginUserProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/api/survey")
+public class SurveyController {
+
+    private final SurveyService surveyService;
+    private final LoginUserProvider loginUserProvider;
+    private final RedisService redisService;
+
+    /**
+     * 로그인한 사용자 정보 추출 및 검증
+     */
+    private Map<String, Object> extractAuthInfo() {
+        Long memberId = loginUserProvider.getLoginMemberId();
+        String email = loginUserProvider.getLoginEmail();
+
+
+        if (memberId == null || email == null) {
+            throw new SecurityException("인증이 필요합니다. 로그인 후 다시 시도해주세요.");
+        }
+
+        Map<String, Object> authInfo = new HashMap<>();
+        authInfo.put("memberId", memberId);
+        authInfo.put("email", email);
+        return authInfo;
+    }
+
+
+    /**
+     * 사용자 설문 응답 저장
+     */
+    @PostMapping("/submit")
+    public ResponseEntity<Map<String, Object>> submitSurvey(
+           @RequestBody UserSurveyRequest request) {
+
+        try {
+            // 1. JWT에서 memberId 추출
+            Map<String, Object> authInfo = extractAuthInfo();
+            Long memberId = (Long) authInfo.get("memberId");
+
+            // 2. 회원 정보에서 industryCode 조회 (현재는 임시값)
+            String industryCode = "56101";
+
+            // 3. BusinessInfoDTO 생성
+            BusinessInfoDTO businessInfoDTO = BusinessInfoDTO.builder()
+                    .memberId(memberId)
+                    .loanPurpose(request.getLoanPurpose())
+                    .industryCode(industryCode)
+                    .businessPeriod(request.getBusinessPeriod())
+                    .revenue(request.getRevenue())
+                    .employees(request.getEmployees())
+                    .placeType(request.getPlaceType())
+                    .build();
+
+            // 4. 설문 응답 저장
+            Long businessId = surveyService.saveUserSurvey(businessInfoDTO);
+
+            // 5. 성공 응답
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", true);
+            response.put("message", "설문 응답이 저장되었습니다.");
+            response.put("businessId", businessId);
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            // 6. 에러 응답
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("success", false);
+            errorResponse.put("message", "설문 응답 저장 중 오류가 발생했습니다: " + e.getMessage());
+
+            return ResponseEntity.badRequest().body(errorResponse);
+        }
+    }
+}

--- a/src/main/java/com/guideon/document/controller/SurveyController.java
+++ b/src/main/java/com/guideon/document/controller/SurveyController.java
@@ -24,7 +24,6 @@ public class SurveyController {
 
     private final SurveyService surveyService;
     private final LoginUserProvider loginUserProvider;
-    private final RedisService redisService;
 
     /**
      * 로그인한 사용자 정보 추출 및 검증

--- a/src/main/java/com/guideon/document/domain/BusinessInfoVO.java
+++ b/src/main/java/com/guideon/document/domain/BusinessInfoVO.java
@@ -19,5 +19,4 @@ public class BusinessInfoVO {
     private Integer employees; // 상시근로자 수
     private String placeType; // 사업장 형태
     private Date createdAt; // 생성일
-    private Date updatedAt; // 수정일
 }

--- a/src/main/java/com/guideon/document/domain/BusinessInfoVO.java
+++ b/src/main/java/com/guideon/document/domain/BusinessInfoVO.java
@@ -1,0 +1,23 @@
+package com.guideon.document.domain;
+
+import lombok.*;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BusinessInfoVO {
+
+    private Long businessId; // 사업체 아이디
+    private Long memberId; // 회원 아이디
+    private String loanPurpose; // 대출목적
+    private String industryCode; // 업종코드
+    private Integer businessPeriod; // 업력
+    private Long revenue; // 연 매출
+    private Integer employees; // 상시근로자 수
+    private String placeType; // 사업장 형태
+    private Date createdAt; // 생성일
+    private Date updatedAt; // 수정일
+}

--- a/src/main/java/com/guideon/document/domain/IndustryRulesVO.java
+++ b/src/main/java/com/guideon/document/domain/IndustryRulesVO.java
@@ -1,0 +1,20 @@
+package com.guideon.document.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class IndustryRulesVO {
+    private Long id;                    // id
+    private String industryCode;        // 업종코드
+    private String industryName;        // 업종명
+    private Boolean isLoanEligible;     // 융자조건 제외 여부
+    private Integer employeeLimit;      // 상시근로자 제한
+    private Boolean hasSpecialCondition; // 특별 조건
+    private Long maxRevenue;            // 최대 매출액
+}

--- a/src/main/java/com/guideon/document/domain/PolicyVO.java
+++ b/src/main/java/com/guideon/document/domain/PolicyVO.java
@@ -1,0 +1,42 @@
+package com.guideon.document.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * 정책 자금 VO
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PolicyVO {
+
+    private Long policyId;           // id
+    private String policyName;       // 정책자금명
+    private String policyType;       // 자금유형 (직접/대리)
+    private String loanPurpose;      // 대출목적 (운전/시설)
+    private Integer minBusinessPeriod; // 최소 업력
+    private Integer maxBusinessPeriod; // 최대 업력
+    private Long minRevenue;         // 최소 매출
+    private Long maxRevenue;         // 최대 매출
+    private String requiredDocuments; // 필수 서류 (json)
+    private String specialConditions; // 조건부 서류 (json)
+    private Long loanLimit;          // 대출 한도(원)
+    private Integer termYears;       // 대출기간(년)
+    private Integer graceYears;      // 거치기간(년)
+    private String quarter;          // 분기
+    private BigDecimal baseRate;     // 기준금리
+    private BigDecimal spreadPp;     // 가산금리
+    private String rateType;         // 금리 유형(고정/변동)
+    private BigDecimal maxDiscount;  // 최대우대금리
+    private String discountRules;    // 우대금리 조건
+    private Boolean isActive;        // 활성화 여부
+    private Date createdAt;          // 생성시각
+    private Date updatedAt;          // 수정시각
+}

--- a/src/main/java/com/guideon/document/dto/BusinessInfoDTO.java
+++ b/src/main/java/com/guideon/document/dto/BusinessInfoDTO.java
@@ -1,0 +1,37 @@
+package com.guideon.document.dto;
+
+import com.guideon.document.domain.BusinessInfoVO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 설문으로 받은 데이터를 저장하기 위한 DTO
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BusinessInfoDTO {
+
+    private Long memberId; // 회원 아이디
+    private String loanPurpose; // 대출목적
+    private String industryCode; // 업종코드
+    private Integer businessPeriod; // 업력
+    private Long revenue; // 연 매출
+    private Integer employees; // 상시근로자 수
+    private String placeType; // 사업장 형태
+
+    public BusinessInfoVO toVO(){
+        return BusinessInfoVO.builder()
+                .memberId(memberId)
+                .loanPurpose(loanPurpose)
+                .industryCode(industryCode)
+                .businessPeriod(businessPeriod)
+                .revenue(revenue)
+                .employees(employees)
+                .placeType(placeType)
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/document/dto/PolicyDTO.java
+++ b/src/main/java/com/guideon/document/dto/PolicyDTO.java
@@ -1,0 +1,49 @@
+package com.guideon.document.dto;
+
+import com.guideon.document.domain.PolicyVO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PolicyDTO {
+
+    private Long policyId;           // id
+    private String policyName;       // 정책자금명
+    private String policyType;       // 자금유형 (직접/대리)
+    private String loanPurpose;      // 대출목적 (운전/시설)
+    private Long loanLimit;          // 대출 한도(원)
+    private Integer termYears;       // 대출기간(년)
+    private Integer graceYears;      // 거치기간(년)
+    private String quarter;          // 분기
+    private BigDecimal baseRate;     // 기준금리
+    private BigDecimal spreadPp;     // 가산금리
+    private String rateType;         // 금리 유형(고정/변동)
+    private BigDecimal maxDiscount;  // 최대우대금리
+
+    /**
+     * PolicyVO -> PolicyDTO 변환
+     */
+    public static PolicyDTO fromVO(PolicyVO vo) {
+        return PolicyDTO.builder()
+                .policyId(vo.getPolicyId())
+                .policyName(vo.getPolicyName())
+                .policyType(vo.getPolicyType())
+                .loanPurpose(vo.getLoanPurpose())
+                .loanLimit(vo.getLoanLimit())
+                .termYears(vo.getTermYears())
+                .graceYears(vo.getGraceYears())
+                .quarter(vo.getQuarter())
+                .baseRate(vo.getBaseRate())
+                .spreadPp(vo.getSpreadPp())
+                .rateType(vo.getRateType())
+                .maxDiscount(vo.getMaxDiscount())
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/document/dto/UserSurveyRequest.java
+++ b/src/main/java/com/guideon/document/dto/UserSurveyRequest.java
@@ -1,0 +1,24 @@
+package com.guideon.document.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 설문 조사 요청 DTO
+ * : 설문에서 입력한 요청 데이터
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserSurveyRequest {
+
+    private String loanPurpose; // 대출목적
+    private Integer businessPeriod; // 업력
+    private Long revenue; // 연 매출
+    private Integer employees; // 상시근로자 수
+    private String placeType; // 사업장 형태
+
+}

--- a/src/main/java/com/guideon/document/mapper/BusinessInfoMapper.java
+++ b/src/main/java/com/guideon/document/mapper/BusinessInfoMapper.java
@@ -1,0 +1,23 @@
+package com.guideon.document.mapper;
+
+import com.guideon.document.domain.BusinessInfoVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface BusinessInfoMapper {
+
+    /**
+     * 사용자 사업체 정보 저장
+     */
+    void insert(BusinessInfoVO businessInfoVO);
+
+    /**
+     * 사업체 정보 ID로 조회
+     */
+    BusinessInfoVO selectByBusinessId(Long businessId);
+
+    /**
+     * 회원 ID로 조회
+     */
+    BusinessInfoVO selectByMemberId(Long memberId);
+}

--- a/src/main/java/com/guideon/document/mapper/IndustryRulesMapper.java
+++ b/src/main/java/com/guideon/document/mapper/IndustryRulesMapper.java
@@ -1,0 +1,13 @@
+package com.guideon.document.mapper;
+
+import com.guideon.document.domain.IndustryRulesVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IndustryRulesMapper {
+
+    /**
+     * 업종코드로 소상공인 조건 조회 (industry_rules 테이블)
+     */
+    IndustryRulesVO selectIndustryRuleByCode(String industryCode);
+}

--- a/src/main/java/com/guideon/document/mapper/PolicyMapper.java
+++ b/src/main/java/com/guideon/document/mapper/PolicyMapper.java
@@ -1,0 +1,15 @@
+package com.guideon.document.mapper;
+
+import com.guideon.document.domain.IndustryRulesVO;
+import com.guideon.document.domain.PolicyVO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.*;
+
+@Mapper
+public interface PolicyMapper {
+    /**
+     * 활성화된 정책자금 전체 조회
+     */
+    List<PolicyVO> selectActivePolicies();
+}

--- a/src/main/java/com/guideon/document/service/PolicyService.java
+++ b/src/main/java/com/guideon/document/service/PolicyService.java
@@ -1,0 +1,22 @@
+package com.guideon.document.service;
+
+import com.guideon.document.dto.PolicyDTO;
+
+import java.util.List;
+
+public interface PolicyService {
+
+    /**
+     * 소상공인 자격 판별 메서드
+     * @param businessId : 사업자 정보 아이디
+     * @return 소상공인이면 true, 아니면 false
+     */
+    boolean isSmallBusiness(Long businessId);
+
+    /**
+     * 사업체 정보 기반 적합한 정책자금 필터링 메서드
+     * @param businessId : 사업자 정보 아이디
+     * @return 사업자 정보 기반 신청가능한 정책자금 DTO 리스트
+     */
+    List<PolicyDTO> filterEligiblePolicies(Long businessId);
+}

--- a/src/main/java/com/guideon/document/service/PolicyServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/PolicyServiceImpl.java
@@ -1,0 +1,123 @@
+package com.guideon.document.service;
+
+import com.guideon.document.domain.BusinessInfoVO;
+import com.guideon.document.domain.IndustryRulesVO;
+import com.guideon.document.domain.PolicyVO;
+import com.guideon.document.dto.PolicyDTO;
+import com.guideon.document.mapper.BusinessInfoMapper;
+import com.guideon.document.mapper.IndustryRulesMapper;
+import com.guideon.document.mapper.PolicyMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class PolicyServiceImpl implements PolicyService {
+
+    private final BusinessInfoMapper businessInfoMapper;
+    private final PolicyMapper policyMapper;
+    private final IndustryRulesMapper industryRulesMapper;
+
+    @Override
+    public boolean isSmallBusiness(Long businessId) {
+
+        log.info("소상공인 판별 시작");
+
+        BusinessInfoVO businessInfoVO = businessInfoMapper.selectByBusinessId(businessId);
+
+        if (businessInfoVO == null) {
+            throw new IllegalArgumentException("존재하지 않는 사업체 정보입니다. businessId: " + businessId);
+        }
+
+        // 업종 조건 조회
+        IndustryRulesVO industryRule = industryRulesMapper.selectIndustryRuleByCode(businessInfoVO.getIndustryCode());
+
+        if (industryRule == null) {
+            throw new IllegalArgumentException("업종 조건을 찾을 수 없습니다. industryCode: " + businessInfoVO.getIndustryCode());
+        }
+
+        // 1. 상시근로자 수 체크
+        if (businessInfoVO.getEmployees() >= industryRule.getEmployeeLimit()) {
+            log.info("소상공인 자격 미달 - 상시근로자 수: {}명 (기준: {}명 미만)",
+                    businessInfoVO.getEmployees(), industryRule.getEmployeeLimit());
+            return false;
+        }
+
+        // 2. 연매출 체크
+        if (industryRule.getMaxRevenue() != null &&
+                businessInfoVO.getRevenue() >= industryRule.getMaxRevenue()) {
+            log.info("소상공인 자격 미달 - 연매출: {}원 (기준: {}원 미만)",
+                    businessInfoVO.getRevenue(), industryRule.getMaxRevenue());
+            return false;
+        }
+
+        log.info("소상공인 자격 요건 충족 - 업종: {}, 직원: {}명, 매출: {}원",
+                businessInfoVO.getIndustryCode(),
+                businessInfoVO.getEmployees(),
+                businessInfoVO.getRevenue());
+
+        return true;
+    }
+
+    @Override
+    public List<PolicyDTO> filterEligiblePolicies(Long businessId) {
+
+        log.info("정책자금 필터링 시작: businessId={}", businessId);
+
+        BusinessInfoVO businessInfoVO = businessInfoMapper.selectByBusinessId(businessId);
+
+        if (businessInfoVO == null) {
+            throw new IllegalArgumentException("존재하지 않는 사업체 정보입니다. businessId: " + businessId);
+        }
+
+        // 활성화된 정책자금 조회
+        List<PolicyVO> activePolicies = policyMapper.selectActivePolicies();
+        List<PolicyDTO> eligiblePolicies = new ArrayList<>();
+
+        log.info("전체 활성 정책자금 수: {}", activePolicies.size());
+
+        // 각 정책자금에 대해 자격 조건 체크
+        for (PolicyVO policy : activePolicies) {
+
+            // 1. 대출목적 매칭 (운전자금/시설자금)
+            if (policy.getLoanPurpose() != null &&
+                    !policy.getLoanPurpose().equals(businessInfoVO.getLoanPurpose())) {
+                continue;
+            }
+
+            // 2. 업력 조건 체크
+            if (policy.getMinBusinessPeriod() != null &&
+                    businessInfoVO.getBusinessPeriod() < policy.getMinBusinessPeriod()) {
+                continue;
+            }
+
+            if (policy.getMaxBusinessPeriod() != null &&
+                    businessInfoVO.getBusinessPeriod() > policy.getMaxBusinessPeriod()) {
+                continue;
+            }
+
+            // 3. 연매출 조건 체크
+            if (policy.getMinRevenue() != null &&
+                    businessInfoVO.getRevenue() < policy.getMinRevenue()) {
+                continue;
+            }
+
+            if (policy.getMaxRevenue() != null &&
+                    businessInfoVO.getRevenue() > policy.getMaxRevenue()) {
+                continue;
+            }
+
+            // 모든 조건을 통과한 정책자금 추가
+            eligiblePolicies.add(PolicyDTO.fromVO(policy));
+            log.debug("적합한 정책자금: {}", policy.getPolicyName());
+        }
+
+        log.info("적합한 정책자금 수: {}", eligiblePolicies.size());
+
+        return eligiblePolicies;
+    }
+}

--- a/src/main/java/com/guideon/document/service/SurveyService.java
+++ b/src/main/java/com/guideon/document/service/SurveyService.java
@@ -1,0 +1,11 @@
+package com.guideon.document.service;
+
+import com.guideon.document.dto.BusinessInfoDTO;
+
+public interface SurveyService {
+
+    /**
+     * 사용자 설문 응답 저장
+     */
+    public Long saveUserSurvey(BusinessInfoDTO businessInfoDTO);
+}

--- a/src/main/java/com/guideon/document/service/SurveyServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/SurveyServiceImpl.java
@@ -1,0 +1,30 @@
+package com.guideon.document.service;
+
+import com.guideon.document.domain.BusinessInfoVO;
+import com.guideon.document.dto.BusinessInfoDTO;
+import com.guideon.document.mapper.BusinessInfoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyServiceImpl implements SurveyService {
+
+    private final BusinessInfoMapper businessInfoMapper;
+
+    /**
+     * 사용자 설문 응답 user_business_info에 저장
+     */
+    @Override
+    public Long saveUserSurvey(BusinessInfoDTO businessInfoDTO) {
+
+        // 1. DTO의 toVO() 메소드 사용하여 변환
+        BusinessInfoVO businessInfoVO = businessInfoDTO.toVO();
+
+        // 2. DB 저장
+        businessInfoMapper.insert(businessInfoVO);
+
+        // 3. 생성된 businessId 반환
+        return businessInfoVO.getBusinessId();
+    }
+}

--- a/src/main/resources/com/guideon/community/mapper/MemberLookupMapper.xml
+++ b/src/main/resources/com/guideon/community/mapper/MemberLookupMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.guideon.community.mapper.MemberLookupMapper">
+    <select id="findMemberIdByEmail" parameterType="string" resultType="long">
+        SELECT member_id FROM member WHERE email = #{email}
+    </select>
+</mapper>

--- a/src/main/resources/com/guideon/document/mapper/BusinessInfoMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/BusinessInfoMapper.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.document.mapper.BusinessInfoMapper">
+
+    <!-- 사업체 정보 저장 -->
+    <insert id="insert" parameterType="BusinessInfoVO"
+            useGeneratedKeys="true" keyProperty="businessId">
+        INSERT INTO user_business_info (
+            member_id,
+            loan_purpose,
+            industry_code,
+            business_period,
+            revenue,
+            employees,
+            place_type
+        ) VALUES (
+                     #{memberId},
+                     #{loanPurpose},
+                     #{industryCode},
+                     #{businessPeriod},
+                     #{revenue},
+                     #{employees},
+                     #{placeType}
+                 )
+    </insert>
+
+    <!-- ID로 조회 -->
+    <select id="selectByBusinessId" parameterType="long" resultType="BusinessInfoVO">
+        SELECT
+            business_id as businessId,
+            member_id as memberId,
+            loan_purpose as loanPurpose,
+            industry_code as industryCode,
+            business_period as businessPeriod,
+            revenue,
+            employees,
+            place_type as placeType,
+            created_at as createdAt,
+            updated_at as updatedAt
+        FROM user_business_info
+        WHERE business_id = #{businessId}
+    </select>
+
+    <!-- ID로 조회 -->
+    <select id="selectByMemberId" parameterType="long" resultType="BusinessInfoVO">
+        SELECT
+            business_id as businessId,
+            member_id as memberId,
+            loan_purpose as loanPurpose,
+            industry_code as industryCode,
+            business_period as businessPeriod,
+            revenue,
+            employees,
+            place_type as placeType,
+            created_at as createdAt,
+            updated_at as updatedAt
+        FROM user_business_info
+        WHERE member_id = #{memberId}
+    </select>
+
+</mapper>

--- a/src/main/resources/com/guideon/document/mapper/BusinessInfoMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/BusinessInfoMapper.xml
@@ -38,8 +38,7 @@
             revenue,
             employees,
             place_type as placeType,
-            created_at as createdAt,
-            updated_at as updatedAt
+            created_at as createdAt
         FROM user_business_info
         WHERE business_id = #{businessId}
     </select>
@@ -55,8 +54,7 @@
             revenue,
             employees,
             place_type as placeType,
-            created_at as createdAt,
-            updated_at as updatedAt
+            created_at as createdAt
         FROM user_business_info
         WHERE member_id = #{memberId}
     </select>

--- a/src/main/resources/com/guideon/document/mapper/IndustryRulesMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/IndustryRulesMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.document.mapper.IndustryRulesMapper">
+
+    <select id="selectIndustryRuleByCode" parameterType="string" resultType="IndustryRulesVO">
+        SELECT
+            id,
+            industry_code as industryCode,
+            industry_name as industryName,
+            is_loan_eligible as isLoanEligible,
+            employee_limit as employeeLimit,
+            has_special_condition as hasSpecialCondition,
+            max_revenue as maxRevenue
+        FROM industry_rules
+        WHERE industry_code = #{industryCode}
+    </select>
+
+</mapper>

--- a/src/main/resources/com/guideon/document/mapper/PolicyMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/PolicyMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.document.mapper.PolicyMapper">
+
+    <!-- 활성화된 정책자금 전체 조회 -->
+    <select id="selectActivePolicies" resultType="PolicyVO">
+        SELECT
+            policy_id as policyId,
+            policy_name as policyName,
+            policy_type as policyType,
+            loan_purpose as loanPurpose,
+            min_business_period as minBusinessPeriod,
+            max_business_period as maxBusinessPeriod,
+            min_revenue as minRevenue,
+            max_revenue as maxRevenue,
+            required_documents as requiredDocuments,
+            special_conditions as specialConditions,
+            loan_limit as loanLimit,
+            term_years as termYears,
+            grace_years as graceYears,
+            quarter,
+            base_rate as baseRate,
+            spread_pp as spreadPp,
+            rate_type as rateType,
+            max_discount as maxDiscount,
+            discount_rules as discountRules,
+            is_active as isActive,
+            created_at as createdAt,
+            updated_at as updatedAt
+        FROM policies
+        WHERE is_active = 1
+        ORDER BY policy_id
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -10,6 +10,7 @@
 
     <typeAliases>
         <package name="com.guideon.security.account.domain"/>
+        <package name="com.guideon.document.domain"/>
     </typeAliases>
 
     <typeHandlers>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
1. 사용자 질문에 대한 답변을 요청하면 답변 기반 사용자 정보를 저장
2. 저장된 사용자 정보를 기반으로 맞춤형 정책 자금 목록을 조회
- `.env`, `.gitignore` 반영
- 

## 📖 작업 내용 
**🗄️ 데이터베이스 설계**
- 테이블 구조 설계: user_business_info, industry_rules, policies 테이블 스키마 정의
- 외래키 관계 설정: user_business_info.industry_code → industry_rules.industry_code 참조 관계 구성
- 회원가입 시 입력 받는 업종코드 테이블과 통일 필요

**🏗️ 도메인 객체 및 DTO 구현**
- VO 클래스: BusinessInfoVO, PolicyVO, IndustryRulesVO 생성 (사용자 사업 정보, 정책자금, 업종에 따른 조건)
- DTO 클래스: BusinessInfoDTO, UserSurveyRequest, PolicyDTO (사용자 사업 정보, 질문 답변 요청, 정책자금)

**🎯 비즈니스 로직 구현**

- 설문 저장 서비스: 사용자 사업체 정보 입력 및 저장 로직
- 소상공인 자격 판별: industry_rules 테이블 기반 자격 요건 검증 (업종코드, 해당 업종 상시근로자 수, 해당 업종 매출액)
- 정책자금 필터링: 대출목적, 업력, 연매출 조건에 따른 맞춤형 정책자금 추출

**🌐 API 엔드포인트 구현**

- 설문 제출: `POST /api/document/survey` - 사업체 정보 저장
- 정책자금 조회: `GET /api/policy/{businessId}` - 맞춤형 정책자금 목록 반환

**🧪테스트 결과**
- 질문 응답에 대해 사용자 정보 저장 확인 (`200 OK`)
- 맞춤 정책 자금 목록 반환 확인 (`200 OK`)
- 업종 코드가 잘못됐을 경우 서버 오류 반환 (`500`)

<img width="853" height="779" alt="스크린샷 2025-09-05 오후 2 26 54" src="https://github.com/user-attachments/assets/2f466cfc-10e2-4c83-badd-0b5cf96b5837" />

<img width="853" height="779" alt="스크린샷 2025-09-05 오후 2 26 59" src="https://github.com/user-attachments/assets/d71e1fac-1bfb-4f83-a7a3-3a78ab0fd1ba" />



## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #5 
