### PR TITLE
feat: 정책지원금 기능 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-# Redis
-REDIS_PASSWORD=
-# JWT 관련
-JWT_SECRET=TestSecretKey_AtLeast_32_Characters_Long_123456
-
-DB_URL=jdbc:log4jdbc:mysql://localhost:3306/guideon
-DB_USERNAME=root
-DB_PASSWORD=1234

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabind}"
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCoreAnn}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonCoreAnn}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonCoreAnn}"
 
     // ===== 데이터베이스 관련 의존성 =====
     implementation 'com.mysql:mysql-connector-j:9.3.0'

--- a/src/main/java/com/guideon/config/JacksonConfig.java
+++ b/src/main/java/com/guideon/config/JacksonConfig.java
@@ -1,0 +1,59 @@
+package com.guideon.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Jackson JSON 직렬화/역직렬화 설정
+ */
+@Configuration
+public class JacksonConfig implements WebMvcConfigurer {
+
+    // 날짜 포맷 상수
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Java 8 시간 타입 지원 모듈 등록
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+        // LocalDateTime을 원하는 형식으로 직렬화
+        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DATE_TIME_FORMATTER));
+
+        mapper.registerModule(javaTimeModule);
+
+        // 배열 형태가 아닌 ISO 형태로 출력 (WRITE_DATES_AS_TIMESTAMPS 비활성화)
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // null 값은 출력하지 않음 (선택사항)
+        // mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        return mapper;
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        // Jackson HTTP 메시지 컨버터 설정
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper());
+
+        // 첫 번째로 추가하여 우선순위 보장
+        converters.add(0, converter);
+    }
+}

--- a/src/main/java/com/guideon/config/RootConfig.java
+++ b/src/main/java/com/guideon/config/RootConfig.java
@@ -23,13 +23,15 @@ import javax.sql.DataSource;
         "com.guideon.member.mapper",
         "com.guideon.document.mapper",
         "com.guideon.community.mapper",
+        "com.guideon.funds.mapper"
 })
 @ComponentScan(basePackages = {
         "com.guideon.member.service",
         "com.guideon.common.redis",
         "com.guideon.document.service",
         "com.guideon.community",      // 서비스/컨트롤러/예외
-        "com.guideon.common"          // 공통 응답/예외/스토리지
+        "com.guideon.common",          // 공통 응답/예외/스토리지
+        "com.guideon.funds"
 })
 @EnableTransactionManagement
 public class RootConfig {

--- a/src/main/java/com/guideon/config/ServletConfig.java
+++ b/src/main/java/com/guideon/config/ServletConfig.java
@@ -13,7 +13,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "com.guideon.security.controller",
         "com.guideon.document.controller",
         "com.guideon.community.controller",
-        "com.guideon.common.exception"   // GlobalExceptionHandler
+        "com.guideon.common.exception",   // GlobalExceptionHandler
+        "com.guideon.funds"
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/com/guideon/config/WebConfig.java
+++ b/src/main/java/com/guideon/config/WebConfig.java
@@ -43,7 +43,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
     @Override
     protected Class<?>[] getRootConfigClasses() {
         // 순서: EnvConfig -> RootConfig -> SecurityConfig -> RedisConfig
-        return new Class[] { RootConfig.class, SecurityConfig.class, RedisConfig.class };
+        return new Class[] { RootConfig.class, SecurityConfig.class, RedisConfig.class, JacksonConfig.class };
     }
 
     @Override

--- a/src/main/java/com/guideon/funds/controller/FundsController.java
+++ b/src/main/java/com/guideon/funds/controller/FundsController.java
@@ -1,0 +1,84 @@
+package com.guideon.funds.controller;
+
+import com.guideon.common.dto.CommonResponseDTO;
+import com.guideon.funds.dto.FundsDetailResponseDTO;
+import com.guideon.funds.dto.FundsListResponseDTO;
+import com.guideon.funds.dto.SavedFundsResponseDTO;
+import com.guideon.funds.service.FundsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 정책지원금 REST API 컨트롤러
+ */
+@Log4j2
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "Funds", description = "정책지원금 API")
+public class FundsController {
+
+    private final FundsService fundsService;
+
+    @GetMapping("/funds")
+    @Operation(summary = "정책지원금 전체 목록 조회", description = "모든 정책지원금을 조회합니다.")
+    public ResponseEntity<CommonResponseDTO<List<FundsListResponseDTO>>> getAllFunds() {
+        List<FundsListResponseDTO> fundsList = fundsService.getAllFunds();
+        return ResponseEntity.ok(CommonResponseDTO.success("정책지원금 목록을 성공적으로 조회했습니다.", fundsList));
+    }
+
+    @GetMapping("/funds/{fundsId}")
+    @Operation(summary = "정책지원금 상세 조회", description = "특정 정책지원금의 상세 정보를 조회합니다.")
+    public ResponseEntity<CommonResponseDTO<FundsDetailResponseDTO>> getFundsDetail(
+            @Parameter(description = "정책지원금 ID", required = true)
+            @PathVariable Long fundsId
+    ) {
+        FundsDetailResponseDTO fundsDetail = fundsService.getFundsDetail(fundsId);
+        return ResponseEntity.ok(CommonResponseDTO.success("정책지원금 상세 정보를 성공적으로 조회했습니다.", fundsDetail));
+    }
+    @GetMapping("/funds/search")
+    @Operation(summary = "정책지원금 이름 검색", description = "정책지원금 이름으로 검색합니다.")
+    public ResponseEntity<CommonResponseDTO<List<FundsListResponseDTO>>> searchFunds(
+            @Parameter(description = "검색 키워드", required = true)
+            @RequestParam String keyword
+    ) {
+        log.info("GET /api/funds/search - keyword: {}", keyword);
+
+        List<FundsListResponseDTO> fundsList = fundsService.searchFundsByName(keyword);
+        return ResponseEntity.ok(CommonResponseDTO.success("정책지원금 검색을 성공적으로 완료했습니다.", fundsList));
+    }
+
+    @PostMapping("/saved-funds/{fundsId}")
+    @Operation(summary = "정책지원금 북마크", description = "정책지원금을 북마크에 추가합니다.")
+    public ResponseEntity<CommonResponseDTO<Void>> saveFunds(
+            @Parameter(description = "정책지원금 ID", required = true)
+            @PathVariable Long fundsId
+    ) {
+        fundsService.saveFunds(fundsId);
+        return ResponseEntity.ok(CommonResponseDTO.success("정책지원금이 북마크에 추가되었습니다."));
+    }
+
+    @DeleteMapping("/saved-funds/{fundsId}")
+    @Operation(summary = "정책지원금 북마크 해제", description = "정책지원금을 북마크에서 제거합니다.")
+    public ResponseEntity<CommonResponseDTO<Void>> unsaveFunds(
+            @Parameter(description = "정책지원금 ID", required = true)
+            @PathVariable Long fundsId
+    ) {
+        fundsService.unsaveFunds(fundsId);
+        return ResponseEntity.ok(CommonResponseDTO.success("정책지원금 북마크가 해제되었습니다."));
+    }
+
+    @GetMapping("/saved-funds")
+    @Operation(summary = "북마크한 정책지원금 목록 조회", description = "사용자가 북마크한 정책지원금 목록을 조회합니다.")
+    public ResponseEntity<CommonResponseDTO<List<SavedFundsResponseDTO>>> getSavedFundsList() {
+        List<SavedFundsResponseDTO> savedFundsList = fundsService.getSavedFundsList();
+        return ResponseEntity.ok(CommonResponseDTO.success("북마크한 정책지원금 목록을 성공적으로 조회했습니다.", savedFundsList));
+    }
+}

--- a/src/main/java/com/guideon/funds/controller/SupportCenterController.java
+++ b/src/main/java/com/guideon/funds/controller/SupportCenterController.java
@@ -1,0 +1,187 @@
+package com.guideon.funds.controller;
+
+import com.guideon.common.dto.CommonResponseDTO;
+import com.guideon.funds.domain.SupportCenter;
+import com.guideon.funds.dto.CoordinateUpdateResponseDTO;
+import com.guideon.funds.dto.NearestCenterRequestDTO;
+import com.guideon.funds.dto.NearestCenterResponseDTO;
+import com.guideon.funds.dto.SupportCenterListResponseDTO;
+import com.guideon.funds.service.CoordinateUpdateService;
+import com.guideon.funds.service.NearestCenterService;
+import com.guideon.funds.service.SupportCenterService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 지원센터 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/support-centers")
+@Api(tags = "지원센터 API", description = "지원센터 관련 API")
+public class SupportCenterController {
+
+    @Autowired
+    private SupportCenterService supportCenterService;
+    
+    @Autowired
+    private CoordinateUpdateService coordinateUpdateService;
+    
+    @Autowired
+    private NearestCenterService nearestCenterService;
+    
+    /**
+     * 전체 지원센터 목록 조회 API
+     * 프론트엔드 드롭다운에서 사용할 전체 센터 목록
+     */
+    @ResponseBody
+    @ApiOperation(value = "전체 지원센터 목록 조회", notes = "모든 지원센터의 목록을 조회합니다. 프론트엔드 드롭다운에서 사용됩니다.")
+    @GetMapping("")
+    public ResponseEntity<CommonResponseDTO<SupportCenterListResponseDTO>> getAllCenters() {
+        try {
+            List<SupportCenter> centers = supportCenterService.getAllCenters();
+            SupportCenterListResponseDTO responseData = new SupportCenterListResponseDTO(centers);
+
+            CommonResponseDTO<SupportCenterListResponseDTO> response =
+                CommonResponseDTO.success("전체 지원센터 목록 조회 성공", responseData);
+            
+            return new ResponseEntity<>(response, HttpStatus.OK);
+            
+        } catch (Exception e) {
+            
+            CommonResponseDTO<SupportCenterListResponseDTO> response =
+                CommonResponseDTO.error("지원센터 목록 조회 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            
+            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    
+    /**
+     * 좌표가 있는 지원센터만 조회 API
+     * 지도에 표시할 센터들만 필요할 때 사용
+     */
+    @RequestMapping(value = "/with-coordinates", method = RequestMethod.GET)
+    @ResponseBody
+    @ApiOperation(value = "좌표가 있는 지원센터 목록 조회", notes = "lat, lng 값이 있는 지원센터만 조회합니다.")
+    public ResponseEntity<CommonResponseDTO<SupportCenterListResponseDTO>> getCentersWithCoordinates() {
+        
+        try {
+            List<SupportCenter> centers = supportCenterService.getCentersWithCoordinates();
+            SupportCenterListResponseDTO responseData = new SupportCenterListResponseDTO(centers);
+
+            CommonResponseDTO<SupportCenterListResponseDTO> response =
+                CommonResponseDTO.success("좌표가 있는 지원센터 목록 조회 성공", responseData);
+            
+            return new ResponseEntity<>(response, HttpStatus.OK);
+            
+        } catch (Exception e) {
+            CommonResponseDTO<SupportCenterListResponseDTO> response =
+                CommonResponseDTO.error("지원센터 목록 조회 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            
+            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    
+    /**
+     * 특정 지원센터 좌표 업데이트 API
+     */
+    @RequestMapping(value = "/{centerId}/coordinates", method = RequestMethod.PUT)
+    @ResponseBody
+    @ApiOperation(value = "지원센터 좌표 업데이트", notes = "카카오 Local API를 사용하여 특정 지원센터의 좌표를 업데이트합니다.")
+    public ResponseEntity<CommonResponseDTO<CoordinateUpdateResponseDTO>> updateCenterCoordinates(@PathVariable Long centerId) {
+        
+        try {
+            CoordinateUpdateResponseDTO result = coordinateUpdateService.updateCenterCoordinates(centerId);
+            
+            if (result.isUpdated()) {
+                CommonResponseDTO<CoordinateUpdateResponseDTO> response = 
+                    CommonResponseDTO.success("지원센터 좌표 업데이트 성공", result);
+                
+                return new ResponseEntity<>(response, HttpStatus.OK);
+            } else {
+                CommonResponseDTO<CoordinateUpdateResponseDTO> response = 
+                    CommonResponseDTO.error("지원센터 좌표 업데이트 실패: " + result.getErrorMessage(), HttpStatus.BAD_REQUEST.value());
+                
+                return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+            }
+            
+        } catch (Exception e) {
+            
+            CommonResponseDTO<CoordinateUpdateResponseDTO> response = 
+                CommonResponseDTO.error("좌표 업데이트 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            
+            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    
+    /**
+     * 모든 지원센터 좌표 일괄 업데이트 API
+     */
+    @RequestMapping(value = "/coordinates/batch-update", method = RequestMethod.PUT)
+    @ResponseBody
+    @ApiOperation(value = "모든 지원센터 좌표 일괄 업데이트", notes = "카카오 Local API를 사용하여 모든 지원센터의 좌표를 일괄 업데이트합니다.")
+    public ResponseEntity<CommonResponseDTO<List<CoordinateUpdateResponseDTO>>> updateAllCentersCoordinates() {
+        
+        try {
+            List<CoordinateUpdateResponseDTO> results = coordinateUpdateService.updateAllCentersCoordinates();
+            
+            long successCount = results.stream().mapToLong(r -> r.isUpdated() ? 1 : 0).sum();
+            long totalCount = results.size();
+            
+            String message = String.format("좌표 일괄 업데이트 완료 - 성공: %d개, 전체: %d개", successCount, totalCount);
+            
+            CommonResponseDTO<List<CoordinateUpdateResponseDTO>> response = 
+                CommonResponseDTO.success(message, results);
+            
+            return new ResponseEntity<>(response, HttpStatus.OK);
+            
+        } catch (Exception e) {
+            
+            CommonResponseDTO<List<CoordinateUpdateResponseDTO>> response = 
+                CommonResponseDTO.error("일괄 좌표 업데이트 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            
+            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    
+    /**
+     * 사업장 주소 기반 가장 가까운 센터 찾기 API
+     */
+    @RequestMapping(value = "/nearest", method = RequestMethod.POST)
+    @ResponseBody
+    @ApiOperation(value = "가장 가까운 지원센터 찾기", notes = "사업장 주소를 기반으로 가장 가까운 지원센터를 찾습니다.")
+    public ResponseEntity<CommonResponseDTO<NearestCenterResponseDTO>> findNearestCenters(@RequestBody NearestCenterRequestDTO request) {
+        
+        try {
+            NearestCenterResponseDTO result = nearestCenterService.findNearestCenters(request);
+            
+            if (result.isSuccess()) {
+                String message = String.format("가까운 지원센터 %d개 조회 성공", 
+                                              result.getNearestCenters() != null ? result.getNearestCenters().size() : 0);
+                
+                CommonResponseDTO<NearestCenterResponseDTO> response = 
+                    CommonResponseDTO.success(message, result);
+                
+                return new ResponseEntity<>(response, HttpStatus.OK);
+            } else {
+                CommonResponseDTO<NearestCenterResponseDTO> response = 
+                    CommonResponseDTO.error("가까운 센터 찾기 실패: " + result.getErrorMessage(), HttpStatus.BAD_REQUEST.value());
+                
+                return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+            }
+            
+        } catch (Exception e) {
+            
+            CommonResponseDTO<NearestCenterResponseDTO> response = 
+                CommonResponseDTO.error("가까운 센터 찾기 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+            
+            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/com/guideon/funds/domain/Funds.java
+++ b/src/main/java/com/guideon/funds/domain/Funds.java
@@ -1,0 +1,30 @@
+package com.guideon.funds.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 정책지원금 도메인 객체 (support_fund 테이블)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Funds {
+    private Long id;                // 정책지원금 ID (support_fund.id)
+    private Integer year;           // 연도
+    private String categoryCode;    // 카테고리 코드
+    private String name;            // 정책지원금 명
+    private String status;          // 상태
+    private String target;          // 대상
+    private String purpose;         // 목적
+    private String rate;            // 지원율/금리
+    private String term;            // 지원기간
+    private String limitAmount;     // 지원한도
+    private LocalDateTime createdAt; // 생성일
+    private LocalDateTime updatedAt; // 수정일
+}

--- a/src/main/java/com/guideon/funds/domain/SavedFunds.java
+++ b/src/main/java/com/guideon/funds/domain/SavedFunds.java
@@ -1,0 +1,25 @@
+package com.guideon.funds.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 북마크한 정책지원금 도메인 객체
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavedFunds {
+    private Long savedFundsId;      // 북마크 ID
+    private Long memberId;          // 회원 ID
+    private Long fundsId;           // 정책지원금 ID (support_fund.id 참조)
+    private LocalDateTime createdAt; // 북마크 생성일
+    
+    // 조인을 위한 Funds 정보
+    private Funds funds;
+}

--- a/src/main/java/com/guideon/funds/domain/SupportCenter.java
+++ b/src/main/java/com/guideon/funds/domain/SupportCenter.java
@@ -1,0 +1,29 @@
+package com.guideon.funds.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * 지원센터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SupportCenter {
+    private Long id;
+    private String name;
+    private String jurisdiction;
+    private String address;
+    private String phone;
+    private String fax;
+    private Double lat;
+    private Double lng;
+    private Date createdAt;
+    private Date updatedAt;
+
+}

--- a/src/main/java/com/guideon/funds/dto/CoordinateUpdateResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/CoordinateUpdateResponseDTO.java
@@ -1,0 +1,40 @@
+package com.guideon.funds.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 좌표 업데이트 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "좌표 업데이트 응답")
+public class CoordinateUpdateResponseDTO {
+    
+    @ApiModelProperty(value = "지원센터 ID", example = "1")
+    private Long centerId;
+    
+    @ApiModelProperty(value = "지원센터명", example = "서울지원센터")
+    private String centerName;
+    
+    @ApiModelProperty(value = "검색된 주소", example = "서울 중구 세종대로 110")
+    private String foundAddress;
+    
+    @ApiModelProperty(value = "업데이트된 위도", example = "37.56673456781234")
+    private Double lat;
+    
+    @ApiModelProperty(value = "업데이트된 경도", example = "126.97794838463647")
+    private Double lng;
+    
+    @ApiModelProperty(value = "업데이트 성공 여부", example = "true")
+    private boolean updated;
+    
+    @ApiModelProperty(value = "오류 메시지", example = "주소를 찾을 수 없습니다")
+    private String errorMessage;
+}

--- a/src/main/java/com/guideon/funds/dto/FundsDetailResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/FundsDetailResponseDTO.java
@@ -1,0 +1,50 @@
+package com.guideon.funds.dto;
+
+import com.guideon.funds.domain.Funds;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 정책지원금 상세 조회 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FundsDetailResponseDTO {
+    private Long id;
+    private Integer year;
+    private String categoryCode;
+    private String name;
+    private String status;
+    private String target;
+    private String purpose;
+    private String rate;
+    private String term;
+    private String limitAmount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private boolean isSaved; // 북마크 여부
+    
+    public static FundsDetailResponseDTO from(Funds funds) {
+        return FundsDetailResponseDTO.builder()
+                .id(funds.getId())
+                .year(funds.getYear())
+                .categoryCode(funds.getCategoryCode())
+                .name(funds.getName())
+                .status(funds.getStatus())
+                .target(funds.getTarget())
+                .purpose(funds.getPurpose())
+                .rate(funds.getRate())
+                .term(funds.getTerm())
+                .limitAmount(funds.getLimitAmount())
+                .createdAt(funds.getCreatedAt())
+                .updatedAt(funds.getUpdatedAt())
+                .isSaved(false)
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/funds/dto/FundsListResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/FundsListResponseDTO.java
@@ -1,0 +1,46 @@
+package com.guideon.funds.dto;
+
+import com.guideon.funds.domain.Funds;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 정책지원금 목록 조회 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FundsListResponseDTO {
+    private Long id;
+    private Integer year;
+    private String categoryCode;
+    private String name;
+    private String status;
+    private String target;
+    private String rate;
+    private String term;
+    private String limitAmount;
+    private LocalDateTime createdAt;
+    private boolean isSaved; // 북마크 여부
+    
+    public static FundsListResponseDTO from(Funds funds) {
+        return FundsListResponseDTO.builder()
+                .id(funds.getId())
+                .year(funds.getYear())
+                .categoryCode(funds.getCategoryCode())
+                .name(funds.getName())
+                .status(funds.getStatus())
+                .target(funds.getTarget())
+                .rate(funds.getRate())
+                .term(funds.getTerm())
+                .limitAmount(funds.getLimitAmount())
+                .createdAt(funds.getCreatedAt())
+                .isSaved(false)
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/funds/dto/KakaoApiRequestDTO.java
+++ b/src/main/java/com/guideon/funds/dto/KakaoApiRequestDTO.java
@@ -1,0 +1,25 @@
+package com.guideon.funds.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 API 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "카카오 API 주소 검색 요청")
+public class KakaoApiRequestDTO {
+    
+    @ApiModelProperty(value = "검색할 주소", example = "서울시 중구 세종대로 110")
+    private String address;
+    
+    @ApiModelProperty(value = "지원센터 ID (좌표 업데이트용)", example = "1")
+    private Long centerId;
+}

--- a/src/main/java/com/guideon/funds/dto/KakaoApiResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/KakaoApiResponseDTO.java
@@ -1,0 +1,164 @@
+package com.guideon.funds.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 카카오 API 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiModel(description = "카카오 API 응답")
+public class KakaoApiResponseDTO {
+    
+    @ApiModelProperty(value = "검색 결과 문서")
+    private List<Document> documents;
+    
+    @ApiModelProperty(value = "검색 메타 정보")
+    private Meta meta;
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @ApiModel(description = "검색 결과 문서")
+    public static class Document {
+        
+        @ApiModelProperty(value = "주소명", example = "서울 중구 세종대로 110")
+        private String address_name;
+        
+        @ApiModelProperty(value = "주소 타입", example = "ROAD_ADDR")
+        private String address_type;
+        
+        @ApiModelProperty(value = "X 좌표값 (경도)", example = "126.97794838463647")
+        private String x;
+        
+        @ApiModelProperty(value = "Y 좌표값 (위도)", example = "37.56673456781234")
+        private String y;
+        
+        @ApiModelProperty(value = "지번 주소 정보")
+        private Address address;
+        
+        @ApiModelProperty(value = "도로명 주소 정보")
+        private RoadAddress road_address;
+    }
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @ApiModel(description = "지번 주소 정보")
+    public static class Address {
+        
+        @ApiModelProperty(value = "지번 주소", example = "서울 중구 태평로1가 31")
+        private String address_name;
+        
+        @ApiModelProperty(value = "1단계 지역명 (시도)", example = "서울특별시")
+        private String region_1depth_name;
+        
+        @ApiModelProperty(value = "2단계 지역명 (시군구)", example = "중구")
+        private String region_2depth_name;
+        
+        @ApiModelProperty(value = "3단계 지역명 (동)", example = "태평로1가")
+        private String region_3depth_name;
+        
+        @ApiModelProperty(value = "3단계 지역명 (행정동)", example = "명동")
+        private String region_3depth_h_name;
+        
+        @ApiModelProperty(value = "행정구역코드", example = "1114010100")
+        private String h_code;
+        
+        @ApiModelProperty(value = "법정구역코드", example = "1114010100")
+        private String b_code;
+        
+        @ApiModelProperty(value = "산 여부", example = "N")
+        private String mountain_yn;
+        
+        @ApiModelProperty(value = "지번 주번지", example = "31")
+        private String main_address_no;
+        
+        @ApiModelProperty(value = "지번 부번지", example = "")
+        private String sub_address_no;
+        
+        @ApiModelProperty(value = "X 좌표값 (경도)", example = "126.97794838463647")
+        private String x;
+        
+        @ApiModelProperty(value = "Y 좌표값 (위도)", example = "37.56673456781234")
+        private String y;
+    }
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @ApiModel(description = "도로명 주소 정보")
+    public static class RoadAddress {
+        
+        @ApiModelProperty(value = "도로명 주소", example = "서울 중구 세종대로 110")
+        private String address_name;
+        
+        @ApiModelProperty(value = "건물명", example = "서울특별시청")
+        private String building_name;
+        
+        @ApiModelProperty(value = "1단계 지역명 (시도)", example = "서울특별시")
+        private String region_1depth_name;
+        
+        @ApiModelProperty(value = "2단계 지역명 (시군구)", example = "중구")
+        private String region_2depth_name;
+        
+        @ApiModelProperty(value = "3단계 지역명 (동)", example = "소공동")
+        private String region_3depth_name;
+        
+        @ApiModelProperty(value = "도로명", example = "세종대로")
+        private String road_name;
+        
+        @ApiModelProperty(value = "지하 여부", example = "N")
+        private String underground_yn;
+        
+        @ApiModelProperty(value = "건물 주번지", example = "110")
+        private String main_building_no;
+        
+        @ApiModelProperty(value = "건물 부번지", example = "")
+        private String sub_building_no;
+        
+        @ApiModelProperty(value = "우편번호", example = "04524")
+        private String zone_no;
+        
+        @ApiModelProperty(value = "X 좌표값 (경도)", example = "126.97794838463647")
+        private String x;
+        
+        @ApiModelProperty(value = "Y 좌표값 (위도)", example = "37.56673456781234")
+        private String y;
+    }
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @ApiModel(description = "검색 메타 정보")
+    public static class Meta {
+        
+        @ApiModelProperty(value = "검색된 문서 수", example = "1")
+        private int total_count;
+        
+        @ApiModelProperty(value = "현재 페이지에 노출된 문서 수", example = "1")
+        private int pageable_count;
+        
+        @ApiModelProperty(value = "마지막 페이지 여부", example = "true")
+        private boolean is_end;
+    }
+}

--- a/src/main/java/com/guideon/funds/dto/NearestCenterRequestDTO.java
+++ b/src/main/java/com/guideon/funds/dto/NearestCenterRequestDTO.java
@@ -1,0 +1,25 @@
+package com.guideon.funds.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 가장 가까운 센터 찾기 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "가장 가까운 센터 찾기 요청")
+public class NearestCenterRequestDTO {
+    
+    @ApiModelProperty(value = "사업장 주소", example = "서울시 강남구 역삼동 123-45", required = true)
+    private String businessAddress;
+    
+    @ApiModelProperty(value = "반환할 센터 개수", example = "3", notes = "기본값: 1개")
+    private Integer limit;
+}

--- a/src/main/java/com/guideon/funds/dto/NearestCenterResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/NearestCenterResponseDTO.java
@@ -1,0 +1,57 @@
+package com.guideon.funds.dto;
+
+import com.guideon.funds.domain.SupportCenter;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 가장 가까운 센터 찾기 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "가장 가까운 센터 찾기 응답")
+public class NearestCenterResponseDTO {
+    
+    @ApiModelProperty(value = "검색된 사업장 주소", example = "서울시 강남구 역삼동 123-45")
+    private String searchedAddress;
+    
+    @ApiModelProperty(value = "사업장 위도", example = "37.5665")
+    private Double businessLat;
+    
+    @ApiModelProperty(value = "사업장 경도", example = "126.9780")
+    private Double businessLng;
+    
+    @ApiModelProperty(value = "가까운 센터 목록")
+    private List<NearestCenter> nearestCenters;
+    
+    @ApiModelProperty(value = "검색 성공 여부", example = "true")
+    private boolean success;
+    
+    @ApiModelProperty(value = "오류 메시지", example = "주소를 찾을 수 없습니다")
+    private String errorMessage;
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ApiModel(description = "가까운 센터 정보")
+    public static class NearestCenter {
+        
+        @ApiModelProperty(value = "센터 정보")
+        private SupportCenter center;
+        
+        @ApiModelProperty(value = "거리 (km)", example = "12.34")
+        private Double distanceKm;
+        
+        @ApiModelProperty(value = "순위", example = "1")
+        private Integer rank;
+    }
+}

--- a/src/main/java/com/guideon/funds/dto/SavedFundsResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/SavedFundsResponseDTO.java
@@ -1,0 +1,46 @@
+package com.guideon.funds.dto;
+
+import com.guideon.funds.domain.SavedFunds;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 북마크한 정책지원금 목록 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavedFundsResponseDTO {
+    private Long savedFundsId;
+    private Long id;                // support_fund.id
+    private Integer year;
+    private String categoryCode;
+    private String name;
+    private String status;
+    private String target;
+    private String rate;
+    private String term;
+    private String limitAmount;
+    private LocalDateTime savedAt;
+    
+    public static SavedFundsResponseDTO from(SavedFunds savedFunds) {
+        return SavedFundsResponseDTO.builder()
+                .savedFundsId(savedFunds.getSavedFundsId())
+                .id(savedFunds.getFunds().getId())
+                .year(savedFunds.getFunds().getYear())
+                .categoryCode(savedFunds.getFunds().getCategoryCode())
+                .name(savedFunds.getFunds().getName())
+                .status(savedFunds.getFunds().getStatus())
+                .target(savedFunds.getFunds().getTarget())
+                .rate(savedFunds.getFunds().getRate())
+                .term(savedFunds.getFunds().getTerm())
+                .limitAmount(savedFunds.getFunds().getLimitAmount())
+                .savedAt(savedFunds.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/funds/dto/SupportCenterListResponseDTO.java
+++ b/src/main/java/com/guideon/funds/dto/SupportCenterListResponseDTO.java
@@ -1,0 +1,30 @@
+package com.guideon.funds.dto;
+
+import com.guideon.funds.domain.SupportCenter;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 지원센터 목록 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "지원센터 목록 응답 정보")
+public class SupportCenterListResponseDTO {
+    private List<SupportCenter> centers;
+    private int count;
+    
+    // 센터 목록으로 생성하는 생성자
+    public SupportCenterListResponseDTO(List<SupportCenter> centers) {
+        this.centers = centers;
+        this.count = centers != null ? centers.size() : 0;
+    }
+}

--- a/src/main/java/com/guideon/funds/exception/FundsAlreadySavedException.java
+++ b/src/main/java/com/guideon/funds/exception/FundsAlreadySavedException.java
@@ -1,0 +1,15 @@
+package com.guideon.funds.exception;
+
+/**
+ * 이미 북마크된 정책지원금을 다시 북마크하려고 할 때 발생하는 예외
+ */
+public class FundsAlreadySavedException extends RuntimeException {
+    
+    public FundsAlreadySavedException(String message) {
+        super(message);
+    }
+    
+    public FundsAlreadySavedException(Long fundsId, Long memberId) {
+        super("이미 북마크된 정책지원금입니다. fundsId: " + fundsId + ", memberId: " + memberId);
+    }
+}

--- a/src/main/java/com/guideon/funds/exception/FundsExceptionAdvice.java
+++ b/src/main/java/com/guideon/funds/exception/FundsExceptionAdvice.java
@@ -1,0 +1,64 @@
+package com.guideon.funds.exception;
+
+import com.guideon.common.dto.CommonResponseDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Funds 관련 예외 처리 Advice
+ */
+@Log4j2
+@RestControllerAdvice(basePackages = "com.guideon.funds")
+public class FundsExceptionAdvice {
+
+    @ExceptionHandler(FundsNotFoundException.class)
+    public ResponseEntity<CommonResponseDTO<Void>> handleFundsNotFoundException(FundsNotFoundException e) {
+        log.error("FundsNotFoundException: {}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(CommonResponseDTO.error("정책지원금을 찾을 수 없습니다.", HttpStatus.NOT_FOUND.value()));
+    }
+
+    @ExceptionHandler(FundsAlreadySavedException.class)
+    public ResponseEntity<CommonResponseDTO<Void>> handleFundsAlreadySavedException(FundsAlreadySavedException e) {
+        log.error("FundsAlreadySavedException: {}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(CommonResponseDTO.error("이미 북마크된 정책지원금입니다.", HttpStatus.CONFLICT.value()));
+    }
+
+    @ExceptionHandler(FundsNotSavedException.class)
+    public ResponseEntity<CommonResponseDTO<Void>> handleFundsNotSavedException(FundsNotSavedException e) {
+        log.error("FundsNotSavedException: {}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponseDTO.error("북마크되지 않은 정책지원금입니다.", HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponseDTO<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("IllegalArgumentException in Funds: {}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponseDTO.error("잘못된 요청입니다.", HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<CommonResponseDTO<Void>> handleIllegalStateException(IllegalStateException e) {
+        log.error("IllegalStateException in Funds: {}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(CommonResponseDTO.error(e.getMessage(), HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponseDTO<Void>> handleGeneralException(Exception e) {
+        log.error("Unexpected exception in Funds: {}", e.getMessage(), e);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponseDTO.error("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.INTERNAL_SERVER_ERROR.value()));
+    }
+}

--- a/src/main/java/com/guideon/funds/exception/FundsNotFoundException.java
+++ b/src/main/java/com/guideon/funds/exception/FundsNotFoundException.java
@@ -1,0 +1,19 @@
+package com.guideon.funds.exception;
+
+/**
+ * 정책지원금을 찾을 수 없을 때 발생하는 예외
+ */
+public class FundsNotFoundException extends RuntimeException {
+    
+    public FundsNotFoundException(String message) {
+        super(message);
+    }
+    
+    public FundsNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    public FundsNotFoundException(Long fundsId) {
+        super("정책지원금을 찾을 수 없습니다. ID: " + fundsId);
+    }
+}

--- a/src/main/java/com/guideon/funds/exception/FundsNotSavedException.java
+++ b/src/main/java/com/guideon/funds/exception/FundsNotSavedException.java
@@ -1,0 +1,15 @@
+package com.guideon.funds.exception;
+
+/**
+ * 북마크되지 않은 정책지원금을 북마크 해제하려고 할 때 발생하는 예외
+ */
+public class FundsNotSavedException extends RuntimeException {
+    
+    public FundsNotSavedException(String message) {
+        super(message);
+    }
+    
+    public FundsNotSavedException(Long fundsId, Long memberId) {
+        super("북마크되지 않은 정책지원금입니다. fundsId: " + fundsId + ", memberId: " + memberId);
+    }
+}

--- a/src/main/java/com/guideon/funds/mapper/FundsMapper.java
+++ b/src/main/java/com/guideon/funds/mapper/FundsMapper.java
@@ -1,0 +1,35 @@
+package com.guideon.funds.mapper;
+
+import com.guideon.funds.domain.Funds;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 정책지원금 Mapper (support_fund 테이블)
+ */
+@Mapper
+public interface FundsMapper {
+    
+    /**
+     * 정책지원금 전체 목록 조회
+     */
+    List<Funds> selectAllFunds();
+    
+    /**
+     * 정책지원금 상세 조회
+     */
+    Funds selectFundsById(@Param("id") Long id);
+
+    /**
+     * 정책지원금 이름으로 검색
+     */
+    List<Funds> selectFundsByNameLike(@Param("keyword") String keyword);
+    
+    /**
+     * 회원별 북마크된 정책지원금 ID 목록 조회
+     */
+    List<Long> selectSavedFundsIdsByMemberId(@Param("memberId") Long memberId);
+
+}

--- a/src/main/java/com/guideon/funds/mapper/SavedFundsMapper.java
+++ b/src/main/java/com/guideon/funds/mapper/SavedFundsMapper.java
@@ -1,0 +1,39 @@
+package com.guideon.funds.mapper;
+
+import com.guideon.funds.domain.SavedFunds;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 북마크한 정책지원금 Mapper
+ */
+@Mapper
+public interface SavedFundsMapper {
+    
+    /**
+     * 정책지원금 북마크 추가
+     */
+    int insertSavedFunds(@Param("memberId") Long memberId, @Param("fundsId") Long fundsId);
+    
+    /**
+     * 정책지원금 북마크 해제
+     */
+    int deleteSavedFunds(@Param("memberId") Long memberId, @Param("fundsId") Long fundsId);
+    
+    /**
+     * 회원별 북마크한 정책지원금 목록 조회 (support_fund 정보 포함)
+     */
+    List<SavedFunds> selectSavedFundsByMemberId(@Param("memberId") Long memberId);
+    
+    /**
+     * 특정 회원의 특정 정책지원금 북마크 여부 확인
+     */
+    boolean existsSavedFunds(@Param("memberId") Long memberId, @Param("fundsId") Long fundsId);
+    
+    /**
+     * 회원별 북마크 개수
+     */
+    int countSavedFundsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/guideon/funds/mapper/SupportCenterMapper.java
+++ b/src/main/java/com/guideon/funds/mapper/SupportCenterMapper.java
@@ -1,0 +1,46 @@
+package com.guideon.funds.mapper;
+
+import com.guideon.funds.domain.SupportCenter;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+/**
+ * 지원센터 Mapper 인터페이스
+ */
+@Mapper
+public interface SupportCenterMapper {
+    
+    /**
+     * 전체 지원센터 목록 조회
+     * @return 전체 지원센터 목록
+     */
+    List<SupportCenter> selectAllCenters();
+    
+    /**
+     * 좌표가 있는 지원센터만 조회
+     * @return 좌표가 있는 지원센터 목록
+     */
+    List<SupportCenter> selectCentersWithCoordinates();
+    
+    /**
+     * 특정 관할구역의 지원센터 조회
+     * @param jurisdiction 관할구역
+     * @return 해당 관할구역의 지원센터 목록
+     */
+    List<SupportCenter> selectCentersByJurisdiction(String jurisdiction);
+    
+    /**
+     * ID로 지원센터 단건 조회
+     * @param id 지원센터 ID
+     * @return 지원센터 정보
+     */
+    SupportCenter selectCenterById(Long id);
+    
+    /**
+     * 지원센터 좌표 업데이트
+     * @param supportCenter 업데이트할 지원센터 정보 (id, lat, lng 필수)
+     * @return 업데이트된 행 수
+     */
+    int updateCenterCoordinates(SupportCenter supportCenter);
+}

--- a/src/main/java/com/guideon/funds/service/AddressPreprocessService.java
+++ b/src/main/java/com/guideon/funds/service/AddressPreprocessService.java
@@ -1,0 +1,109 @@
+package com.guideon.funds.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Pattern;
+
+/**
+ * 주소 전처리 서비스
+ */
+@Service
+public class AddressPreprocessService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(AddressPreprocessService.class);
+    
+    /**
+     * 카카오 API 검색에 적합하도록 주소를 전처리
+     * @param originalAddress 원본 주소
+     * @return 전처리된 주소
+     */
+    public String preprocessAddress(String originalAddress) {
+        if (originalAddress == null || originalAddress.trim().isEmpty()) {
+            return originalAddress;
+        }
+        
+        logger.info("주소 전처리 시작: {}", originalAddress);
+        
+        String processed = originalAddress;
+        
+        // 1. 우편번호 제거 - (12345) 형태
+        processed = processed.replaceAll("\\(\\d{5}\\)", "").trim();
+        
+        // 2. 불필요한 문구 제거
+        processed = processed.replaceAll("\\s+\\d+층.*", ""); // X층 이후 모든 내용 제거
+        processed = processed.replaceAll("\\s*,.*", ""); // 쉼표 이후 모든 내용 제거
+        
+        // 3. 건물명 중복 제거 및 정리
+        // "건물명 건물명" 같은 중복 제거
+        String[] parts = processed.split("\\s+");
+        StringBuilder result = new StringBuilder();
+        
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i].trim();
+            
+            // 빈 문자열 스킵
+            if (part.isEmpty()) continue;
+            
+            // 층수 관련 단어 스킵
+            if (part.matches("\\d+층?") || part.equals("층")) continue;
+            
+            // 중복 단어 제거 (연속된 같은 단어)
+            if (i > 0 && part.equals(parts[i-1])) continue;
+            
+            if (result.length() > 0) {
+                result.append(" ");
+            }
+            result.append(part);
+        }
+        
+        processed = result.toString().trim();
+        
+        // 4. 기본 주소만 추출 (시/군/구 + 도로명/지번 + 번지)
+        // 건물명이 있어도 기본 주소까지만 사용
+        String[] addressParts = processed.split("\\s+");
+        StringBuilder basicAddress = new StringBuilder();
+        
+        for (String part : addressParts) {
+            basicAddress.append(part).append(" ");
+            
+            // 번지가 나오면 거기서 중단 (건물명 제외)
+            if (part.matches(".*\\d+(-\\d+)?$") && basicAddress.toString().split("\\s+").length >= 3) {
+                break;
+            }
+        }
+        
+        processed = basicAddress.toString().trim();
+        
+        logger.info("주소 전처리 완료: {} -> {}", originalAddress, processed);
+        
+        return processed;
+    }
+    
+    /**
+     * 여러 가지 주소 형태로 시도
+     * @param originalAddress 원본 주소
+     * @return 전처리된 주소 배열 (우선순위 순)
+     */
+    public String[] getAddressVariations(String originalAddress) {
+        String basic = preprocessAddress(originalAddress);
+        
+        // 기본 전처리된 주소
+        String variation1 = basic;
+        
+        // 더 간단하게 - 도/시/군/구 + 도로명/동명만
+        String[] parts = basic.split("\\s+");
+        StringBuilder simple = new StringBuilder();
+        for (int i = 0; i < Math.min(parts.length, 3); i++) {
+            if (i > 0) simple.append(" ");
+            simple.append(parts[i]);
+        }
+        String variation2 = simple.toString();
+        
+        // 건물명까지 포함
+        String variation3 = originalAddress.replaceAll("\\(\\d{5}\\)", "").replaceAll("\\s+\\d+층.*", "").trim();
+        
+        return new String[]{variation1, variation2, variation3};
+    }
+}

--- a/src/main/java/com/guideon/funds/service/CoordinateUpdateService.java
+++ b/src/main/java/com/guideon/funds/service/CoordinateUpdateService.java
@@ -1,0 +1,155 @@
+package com.guideon.funds.service;
+
+import com.guideon.funds.domain.SupportCenter;
+import com.guideon.funds.dto.CoordinateUpdateResponseDTO;
+import com.guideon.funds.dto.KakaoApiResponseDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 좌표 업데이트 서비스
+ */
+@Service
+@Transactional
+public class CoordinateUpdateService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(CoordinateUpdateService.class);
+    
+    @Autowired
+    private SupportCenterService supportCenterService;
+    
+    @Autowired
+    private KakaoApiService kakaoApiService;
+    
+    /**
+     * 특정 지원센터의 좌표 업데이트
+     * @param centerId 지원센터 ID
+     * @return 업데이트 결과
+     */
+    public CoordinateUpdateResponseDTO updateCenterCoordinates(Long centerId) {
+        logger.info("지원센터 ID {} 좌표 업데이트 시작", centerId);
+        
+        try {
+            // 1. 지원센터 정보 조회
+            SupportCenter center = supportCenterService.getCenterById(centerId);
+            if (center == null) {
+                return CoordinateUpdateResponseDTO.builder()
+                        .centerId(centerId)
+                        .updated(false)
+                        .errorMessage("지원센터를 찾을 수 없습니다.")
+                        .build();
+            }
+            
+            // 2. 주소가 없으면 실패
+            if (center.getAddress() == null || center.getAddress().trim().isEmpty()) {
+                return CoordinateUpdateResponseDTO.builder()
+                        .centerId(centerId)
+                        .centerName(center.getName())
+                        .updated(false)
+                        .errorMessage("주소 정보가 없습니다.")
+                        .build();
+            }
+            
+            // 3. 카카오 API로 좌표 검색
+            Double[] coordinates = kakaoApiService.getCoordinatesFromAddress(center.getAddress());
+            
+            if (coordinates == null) {
+                return CoordinateUpdateResponseDTO.builder()
+                        .centerId(centerId)
+                        .centerName(center.getName())
+                        .updated(false)
+                        .errorMessage("주소에서 좌표를 찾을 수 없습니다.")
+                        .build();
+            }
+            
+            // 4. 좌표 업데이트
+            center.setLat(coordinates[0]);  // 위도
+            center.setLng(coordinates[1]);  // 경도
+            
+            boolean updateSuccess = supportCenterService.updateCenterCoordinates(center);
+            
+            if (updateSuccess) {
+                logger.info("지원센터 ID {} 좌표 업데이트 성공", centerId);
+                
+                return CoordinateUpdateResponseDTO.builder()
+                        .centerId(centerId)
+                        .centerName(center.getName())
+                        .foundAddress(center.getAddress())
+                        .lat(coordinates[0])
+                        .lng(coordinates[1])
+                        .updated(true)
+                        .build();
+            } else {
+                return CoordinateUpdateResponseDTO.builder()
+                        .centerId(centerId)
+                        .centerName(center.getName())
+                        .updated(false)
+                        .errorMessage("데이터베이스 업데이트에 실패했습니다.")
+                        .build();
+            }
+            
+        } catch (Exception e) {
+            logger.error("지원센터 ID {} 좌표 업데이트 중 오류 발생", centerId, e);
+            
+            return CoordinateUpdateResponseDTO.builder()
+                    .centerId(centerId)
+                    .updated(false)
+                    .errorMessage("처리 중 오류가 발생했습니다: " + e.getMessage())
+                    .build();
+        }
+    }
+    
+    /**
+     * 모든 지원센터의 좌표 일괄 업데이트
+     * @return 업데이트 결과 목록
+     */
+    public List<CoordinateUpdateResponseDTO> updateAllCentersCoordinates() {
+        logger.info("모든 지원센터 좌표 일괄 업데이트 시작");
+        
+        List<CoordinateUpdateResponseDTO> results = new ArrayList<>();
+        
+        try {
+            // 1. 모든 지원센터 조회
+            List<SupportCenter> allCenters = supportCenterService.getAllCenters();
+            
+            logger.info("총 {}개 지원센터의 좌표 업데이트 진행", allCenters.size());
+            
+            // 2. 각 센터별로 좌표 업데이트
+            for (SupportCenter center : allCenters) {
+                CoordinateUpdateResponseDTO result = updateCenterCoordinates(center.getId());
+                results.add(result);
+                
+                // API 호출 제한을 고려한 딜레이 (선택사항)
+                try {
+                    Thread.sleep(100); // 0.1초 대기
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            
+            // 3. 결과 집계
+            long successCount = results.stream().mapToLong(r -> r.isUpdated() ? 1 : 0).sum();
+            long failCount = results.size() - successCount;
+            
+            logger.info("일괄 좌표 업데이트 완료 - 성공: {}개, 실패: {}개", successCount, failCount);
+            
+        } catch (Exception e) {
+            logger.error("일괄 좌표 업데이트 중 오류 발생", e);
+            
+            // 오류 발생시 오류 정보 추가
+            results.add(CoordinateUpdateResponseDTO.builder()
+                    .updated(false)
+                    .errorMessage("일괄 처리 중 오류 발생: " + e.getMessage())
+                    .build());
+        }
+        
+        return results;
+    }
+}

--- a/src/main/java/com/guideon/funds/service/DistanceCalculationService.java
+++ b/src/main/java/com/guideon/funds/service/DistanceCalculationService.java
@@ -1,0 +1,65 @@
+package com.guideon.funds.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * 거리 계산 서비스 (Haversine 공식 사용)
+ */
+@Service
+public class DistanceCalculationService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(DistanceCalculationService.class);
+    
+    // 지구 반지름 (km)
+    private static final double EARTH_RADIUS_KM = 6371.0;
+    
+    /**
+     * Haversine 공식을 사용한 두 좌표 간 거리 계산
+     * @param lat1 첫 번째 지점의 위도
+     * @param lng1 첫 번째 지점의 경도
+     * @param lat2 두 번째 지점의 위도
+     * @param lng2 두 번째 지점의 경도
+     * @return 거리 (km)
+     */
+    public double calculateDistanceKm(double lat1, double lng1, double lat2, double lng2) {
+        logger.debug("거리 계산: ({}, {}) - ({}, {})", lat1, lng1, lat2, lng2);
+        
+        // 위도와 경도를 라디안으로 변환
+        double lat1Rad = Math.toRadians(lat1);
+        double lng1Rad = Math.toRadians(lng1);
+        double lat2Rad = Math.toRadians(lat2);
+        double lng2Rad = Math.toRadians(lng2);
+        
+        // 위도와 경도의 차이
+        double deltaLat = lat2Rad - lat1Rad;
+        double deltaLng = lng2Rad - lng1Rad;
+        
+        // Haversine 공식
+        double a = Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+                   Math.cos(lat1Rad) * Math.cos(lat2Rad) *
+                   Math.sin(deltaLng / 2) * Math.sin(deltaLng / 2);
+        
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        
+        double distance = EARTH_RADIUS_KM * c;
+        
+        logger.debug("계산된 거리: {} km", distance);
+        
+        return distance;
+    }
+    
+    /**
+     * 거리를 반올림하여 반환 (소수점 2자리)
+     * @param lat1 첫 번째 지점의 위도
+     * @param lng1 첫 번째 지점의 경도
+     * @param lat2 두 번째 지점의 위도
+     * @param lng2 두 번째 지점의 경도
+     * @return 반올림된 거리 (km)
+     */
+    public double calculateDistanceKmRounded(double lat1, double lng1, double lat2, double lng2) {
+        double distance = calculateDistanceKm(lat1, lng1, lat2, lng2);
+        return Math.round(distance * 100.0) / 100.0; // 소수점 2자리 반올림
+    }
+}

--- a/src/main/java/com/guideon/funds/service/FundsService.java
+++ b/src/main/java/com/guideon/funds/service/FundsService.java
@@ -1,0 +1,42 @@
+package com.guideon.funds.service;
+
+import com.guideon.funds.dto.FundsDetailResponseDTO;
+import com.guideon.funds.dto.FundsListResponseDTO;
+import com.guideon.funds.dto.SavedFundsResponseDTO;
+
+import java.util.List;
+
+/**
+ * 정책지원금 서비스 인터페이스
+ */
+public interface FundsService {
+
+    /**
+     * 정책지원금 전체 목록 조회
+     */
+    List<FundsListResponseDTO> getAllFunds();
+
+    /**
+     * 정책지원금 상세 조회
+     */
+    FundsDetailResponseDTO getFundsDetail(Long fundsId);
+    /**
+     * 정책지원금 이름으로 검색
+     */
+    List<FundsListResponseDTO> searchFundsByName(String keyword);
+
+    /**
+     * 정책지원금 북마크 추가
+     */
+    void saveFunds(Long fundsId);
+
+    /**
+     * 정책지원금 북마크 해제
+     */
+    void unsaveFunds(Long fundsId);
+
+    /**
+     * 회원별 북마크한 정책지원금 목록 조회
+     */
+    List<SavedFundsResponseDTO> getSavedFundsList();
+}

--- a/src/main/java/com/guideon/funds/service/FundsServiceImpl.java
+++ b/src/main/java/com/guideon/funds/service/FundsServiceImpl.java
@@ -1,0 +1,171 @@
+package com.guideon.funds.service;
+
+import com.guideon.funds.domain.Funds;
+import com.guideon.funds.domain.SavedFunds;
+import com.guideon.funds.dto.FundsDetailResponseDTO;
+import com.guideon.funds.dto.FundsListResponseDTO;
+import com.guideon.funds.dto.SavedFundsResponseDTO;
+import com.guideon.funds.exception.FundsAlreadySavedException;
+import com.guideon.funds.exception.FundsNotFoundException;
+import com.guideon.funds.exception.FundsNotSavedException;
+import com.guideon.funds.mapper.FundsMapper;
+import com.guideon.funds.mapper.SavedFundsMapper;
+import com.guideon.security.util.LoginUserProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 정책지원금 서비스 구현체
+ */
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FundsServiceImpl implements FundsService {
+
+    private final FundsMapper fundsMapper;
+    private final SavedFundsMapper savedFundsMapper;
+    private final LoginUserProvider loginUserProvider;
+
+    @Override
+    public List<FundsListResponseDTO> getAllFunds() {
+        // 모든 정책지원금 조회
+        List<Funds> fundsList = fundsMapper.selectAllFunds();
+        return buildFundsListResponse(fundsList);
+    }
+
+    @Override
+    public FundsDetailResponseDTO getFundsDetail(Long fundsId) {
+        Funds funds = fundsMapper.selectFundsById(fundsId);
+        if (funds == null) {
+            throw new FundsNotFoundException(fundsId);
+        }
+
+        FundsDetailResponseDTO dto = FundsDetailResponseDTO.from(funds);
+
+        // 로그인한 사용자의 북마크 여부 확인
+        Long memberId = getCurrentMemberId();
+        if (memberId != null) {
+            boolean isSaved = savedFundsMapper.existsSavedFunds(memberId, fundsId);
+            dto.setSaved(isSaved);
+        }
+
+        return dto;
+    }
+
+    @Override
+    public List<FundsListResponseDTO> searchFundsByName(String keyword) {
+
+        if (keyword == null || keyword.trim().isEmpty()) {
+            throw new IllegalArgumentException("검색 키워드는 필수입니다.");
+        }
+
+        List<Funds> fundsList = fundsMapper.selectFundsByNameLike(keyword.trim());
+        return buildFundsListResponse(fundsList);
+    }
+
+    /**
+     * FundsList 공통 응답 빌더 (북마크 여부 포함)
+     */
+    private List<FundsListResponseDTO> buildFundsListResponse(List<Funds> fundsList) {
+        // 로그인한 사용자 정보 획득
+        Long memberId = getCurrentMemberId();
+
+        // 해당 회원이 북마크한 정책지원금 ID 목록 조회
+        Set<Long> savedFundsIds = null;
+        if (memberId != null) {
+            savedFundsIds = fundsMapper.selectSavedFundsIdsByMemberId(memberId)
+                    .stream()
+                    .collect(Collectors.toSet());
+        }
+
+        // DTO 변환 및 북마크 여부 설정
+        final Set<Long> finalSavedFundsIds = savedFundsIds;
+        return fundsList.stream()
+                .map(funds -> {
+                    FundsListResponseDTO dto = FundsListResponseDTO.from(funds);
+                    if (finalSavedFundsIds != null) {
+                        dto.setSaved(finalSavedFundsIds.contains(funds.getId()));
+                    }
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void saveFunds(Long fundsId) {
+        Long memberId = getCurrentMemberIdRequired();
+
+        // 정책지원금 존재 여부 확인
+        Funds funds = fundsMapper.selectFundsById(fundsId);
+        if (funds == null) {
+            throw new FundsNotFoundException(fundsId);
+        }
+
+        // 이미 북마크되어 있는지 확인
+        if (savedFundsMapper.existsSavedFunds(memberId, fundsId)) {
+            throw new FundsAlreadySavedException(fundsId, memberId);
+        }
+
+        int result = savedFundsMapper.insertSavedFunds(memberId, fundsId);
+        if (result != 1) {
+            throw new RuntimeException("북마크 추가에 실패했습니다.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void unsaveFunds(Long fundsId) {
+        Long memberId = getCurrentMemberIdRequired();
+
+        // 북마크되어 있는지 확인
+        if (!savedFundsMapper.existsSavedFunds(memberId, fundsId)) {
+            throw new FundsNotSavedException(fundsId, memberId);
+        }
+
+        int result = savedFundsMapper.deleteSavedFunds(memberId, fundsId);
+        if (result != 1) {
+            throw new RuntimeException("북마크 해제에 실패했습니다.");
+        }
+    }
+
+    @Override
+    public List<SavedFundsResponseDTO> getSavedFundsList() {
+        Long memberId = getCurrentMemberIdRequired(); // 인증 필수
+        List<SavedFunds> savedFundsList = savedFundsMapper.selectSavedFundsByMemberId(memberId);
+
+        return savedFundsList.stream()
+                .map(SavedFundsResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 현재 로그인한 사용자 ID 반환 (로그인하지 않은 경우 null)
+     */
+    private Long getCurrentMemberId() {
+        try {
+            return loginUserProvider.getLoginMemberId();
+        } catch (Exception e) {
+            log.debug("User not authenticated: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 현재 로그인한 사용자 ID 반환 (로그인하지 않은 경우 예외 발생)
+     */
+    private Long getCurrentMemberIdRequired() {
+        Long memberId = getCurrentMemberId();
+        if (memberId == null) {
+            throw new IllegalStateException("로그인이 필요한 서비스입니다.");
+        }
+        return memberId;
+    }
+}

--- a/src/main/java/com/guideon/funds/service/KakaoApiService.java
+++ b/src/main/java/com/guideon/funds/service/KakaoApiService.java
@@ -1,0 +1,157 @@
+package com.guideon.funds.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guideon.funds.dto.KakaoApiResponseDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Collections;
+
+/**
+ * 카카오 Local API 서비스
+ */
+@Service
+public class KakaoApiService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(KakaoApiService.class);
+    
+    private static final String KAKAO_API_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    
+    @Value("${kakao.api.key:}")
+    private String kakaoApiKey;
+    
+    @Autowired
+    private AddressPreprocessService addressPreprocessService;
+    
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    
+    public KakaoApiService() {
+        this.restTemplate = new RestTemplate();
+        this.objectMapper = new ObjectMapper();
+    }
+    
+    /**
+     * 카카오 Local API를 통해 주소의 좌표를 검색
+     * @param address 검색할 주소
+     * @return 카카오 API 응답 결과
+     */
+    public KakaoApiResponseDTO searchAddressCoordinates(String address) {
+        logger.info("=== 카카오 API 주소 검색 시작 ===");
+        logger.info("검색 주소: {}", address);
+        
+        try {
+            // API 키 확인
+            if (kakaoApiKey == null || kakaoApiKey.trim().isEmpty()) {
+                logger.error("카카오 API 키가 설정되지 않았습니다.");
+                return null;
+            }
+            
+            logger.info("카카오 API 키 확인 완료: {}****", kakaoApiKey.substring(0, Math.min(8, kakaoApiKey.length())));
+            
+            // URL 생성
+            String url = UriComponentsBuilder.fromHttpUrl(KAKAO_API_URL)
+                    .queryParam("query", address)
+                    .queryParam("analyze_type", "similar")  // 유사한 주소 포함 검색
+                    .build()
+                    .toUriString();
+            
+            // HTTP 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+            headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+            
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+            
+            // API 호출
+            logger.info("카카오 API 호출 URL: {}", url);
+            logger.info("요청 헤더: {}", headers);
+            
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url, 
+                    HttpMethod.GET, 
+                    entity, 
+                    String.class
+            );
+            
+            logger.info("카카오 API 응답 상태: {}", response.getStatusCode());
+            logger.info("카카오 API 응답 내용: {}", response.getBody());
+            
+            // 응답 파싱
+            if (response.getStatusCode() == HttpStatus.OK) {
+                KakaoApiResponseDTO result = objectMapper.readValue(
+                    response.getBody(), 
+                    KakaoApiResponseDTO.class
+                );
+                
+                logger.info("파싱 결과 - 검색 결과: {}개", 
+                           result.getDocuments() != null ? result.getDocuments().size() : 0);
+                
+                if (result.getDocuments() != null && !result.getDocuments().isEmpty()) {
+                    KakaoApiResponseDTO.Document firstResult = result.getDocuments().get(0);
+                    logger.info("첫 번째 결과: address={}, x={}, y={}", 
+                               firstResult.getAddress_name(), firstResult.getX(), firstResult.getY());
+                } else {
+                    logger.warn("검색 결과가 없습니다.");
+                }
+                
+                return result;
+            } else {
+                logger.error("카카오 API 호출 실패 - Status: {}, Body: {}", 
+                           response.getStatusCode(), response.getBody());
+                return null;
+            }
+            
+        } catch (Exception e) {
+            logger.error("카카오 API 호출 중 오류 발생: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+    
+    /**
+     * 첫 번째 검색 결과에서 좌표 추출
+     * @param address 검색할 주소
+     * @return [위도, 경도] 배열, 실패시 null
+     */
+    public Double[] getCoordinatesFromAddress(String address) {
+        logger.info("좌표 추출 시작 - 원본 주소: {}", address);
+        
+        // 여러 형태의 주소로 시도
+        String[] addressVariations = addressPreprocessService.getAddressVariations(address);
+        
+        for (int i = 0; i < addressVariations.length; i++) {
+            String tryAddress = addressVariations[i];
+            logger.info("주소 변형 {}번째 시도: {}", i + 1, tryAddress);
+            
+            KakaoApiResponseDTO result = searchAddressCoordinates(tryAddress);
+            
+            if (result != null && 
+                result.getDocuments() != null && 
+                !result.getDocuments().isEmpty()) {
+                
+                KakaoApiResponseDTO.Document firstResult = result.getDocuments().get(0);
+                
+                try {
+                    double lat = Double.parseDouble(firstResult.getY());  // Y = 위도
+                    double lng = Double.parseDouble(firstResult.getX());  // X = 경도
+                    
+                    logger.info("좌표 추출 성공 - 사용된 주소: {}, 위도: {}, 경도: {}", tryAddress, lat, lng);
+                    
+                    return new Double[]{lat, lng};
+                    
+                } catch (NumberFormatException e) {
+                    logger.error("좌표 변환 실패 - X: {}, Y: {}", firstResult.getX(), firstResult.getY());
+                }
+            }
+        }
+        
+        logger.warn("모든 주소 변형으로 검색 실패: {}", address);
+        return null;
+    }
+}

--- a/src/main/java/com/guideon/funds/service/MockKakaoApiService.java
+++ b/src/main/java/com/guideon/funds/service/MockKakaoApiService.java
@@ -1,0 +1,39 @@
+package com.guideon.funds.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * 카카오 API 목 서비스 (테스트용)
+ */
+@Service
+@Profile("test") // 테스트 프로파일에서만 활성화
+public class MockKakaoApiService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(MockKakaoApiService.class);
+    
+    /**
+     * 목 좌표 데이터 반환 (테스트용)
+     */
+    public Double[] getCoordinatesFromAddress(String address) {
+        logger.info("목 서비스 - 주소: {}", address);
+        
+        // 지역별 대략적인 좌표 반환 (테스트용)
+        if (address.contains("강릉")) {
+            return new Double[]{37.7519, 128.8761}; // 강릉시청 근처
+        } else if (address.contains("춘천")) {
+            return new Double[]{37.8813, 127.7299}; // 춘천시청 근처
+        } else if (address.contains("의정부")) {
+            return new Double[]{37.7380, 127.0334}; // 의정부시청 근처
+        } else if (address.contains("창원")) {
+            return new Double[]{35.2280, 128.6811}; // 창원시청 근처
+        } else if (address.contains("경주")) {
+            return new Double[]{35.8562, 129.2247}; // 경주시청 근처
+        } else {
+            // 기본값: 서울시청
+            return new Double[]{37.5666, 126.9779};
+        }
+    }
+}

--- a/src/main/java/com/guideon/funds/service/NearestCenterService.java
+++ b/src/main/java/com/guideon/funds/service/NearestCenterService.java
@@ -1,0 +1,133 @@
+package com.guideon.funds.service;
+
+import com.guideon.funds.domain.SupportCenter;
+import com.guideon.funds.dto.NearestCenterRequestDTO;
+import com.guideon.funds.dto.NearestCenterResponseDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 가장 가까운 센터 찾기 서비스
+ */
+@Service
+public class NearestCenterService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(NearestCenterService.class);
+    
+    @Autowired
+    private SupportCenterService supportCenterService;
+    
+    @Autowired
+    private KakaoApiService kakaoApiService;
+    
+    @Autowired
+    private DistanceCalculationService distanceCalculationService;
+    
+    /**
+     * 사업장 주소 기반 가장 가까운 센터 찾기
+     * @param request 요청 정보
+     * @return 가까운 센터 목록
+     */
+    public NearestCenterResponseDTO findNearestCenters(NearestCenterRequestDTO request) {
+        logger.info("가까운 센터 찾기 시작 - 주소: {}, 제한: {}개", 
+                   request.getBusinessAddress(), request.getLimit());
+        
+        try {
+            // 1. 사업장 주소의 좌표 조회
+            Double[] businessCoordinates = kakaoApiService.getCoordinatesFromAddress(request.getBusinessAddress());
+            
+            if (businessCoordinates == null) {
+                return NearestCenterResponseDTO.builder()
+                        .searchedAddress(request.getBusinessAddress())
+                        .success(false)
+                        .errorMessage("사업장 주소에서 좌표를 찾을 수 없습니다.")
+                        .build();
+            }
+            
+            double businessLat = businessCoordinates[0];
+            double businessLng = businessCoordinates[1];
+            
+            logger.info("사업장 좌표: 위도={}, 경도={}", businessLat, businessLng);
+            
+            // 2. 좌표가 있는 모든 센터 조회
+            List<SupportCenter> centersWithCoordinates = supportCenterService.getCentersWithCoordinates();
+            
+            if (centersWithCoordinates.isEmpty()) {
+                return NearestCenterResponseDTO.builder()
+                        .searchedAddress(request.getBusinessAddress())
+                        .businessLat(businessLat)
+                        .businessLng(businessLng)
+                        .success(false)
+                        .errorMessage("좌표가 설정된 지원센터가 없습니다.")
+                        .build();
+            }
+            
+            logger.info("좌표가 있는 센터 {}개 발견", centersWithCoordinates.size());
+            
+            // 3. 각 센터와의 거리 계산
+            List<NearestCenterResponseDTO.NearestCenter> nearestCenters = new ArrayList<>();
+            
+            for (SupportCenter center : centersWithCoordinates) {
+                double distance = distanceCalculationService.calculateDistanceKmRounded(
+                    businessLat, businessLng, 
+                    center.getLat(), center.getLng()
+                );
+                
+                nearestCenters.add(
+                    NearestCenterResponseDTO.NearestCenter.builder()
+                        .center(center)
+                        .distanceKm(distance)
+                        .build()
+                );
+                
+                logger.debug("센터: {}, 거리: {} km", center.getName(), distance);
+            }
+            
+            // 4. 거리순 정렬
+            nearestCenters.sort(Comparator.comparing(NearestCenterResponseDTO.NearestCenter::getDistanceKm));
+            
+            // 5. 제한된 개수만 반환 (기본값: 1개)
+            int limit = request.getLimit() != null ? request.getLimit() : 1;
+            List<NearestCenterResponseDTO.NearestCenter> limitedCenters = nearestCenters.stream()
+                    .limit(limit)
+                    .collect(Collectors.toList());
+            
+            // 6. 순위 설정
+            for (int i = 0; i < limitedCenters.size(); i++) {
+                limitedCenters.get(i).setRank(i + 1);
+            }
+            
+            logger.info("가까운 센터 찾기 완료 - 결과: {}개", limitedCenters.size());
+            
+            if (!limitedCenters.isEmpty()) {
+                NearestCenterResponseDTO.NearestCenter closest = limitedCenters.get(0);
+                logger.info("가장 가까운 센터: {} ({}km)", 
+                           closest.getCenter().getName(), closest.getDistanceKm());
+            }
+            
+            return NearestCenterResponseDTO.builder()
+                    .searchedAddress(request.getBusinessAddress())
+                    .businessLat(businessLat)
+                    .businessLng(businessLng)
+                    .nearestCenters(limitedCenters)
+                    .success(true)
+                    .build();
+            
+        } catch (Exception e) {
+            logger.error("가까운 센터 찾기 중 오류 발생", e);
+            
+            return NearestCenterResponseDTO.builder()
+                    .searchedAddress(request.getBusinessAddress())
+                    .success(false)
+                    .errorMessage("처리 중 오류가 발생했습니다: " + e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/guideon/funds/service/SupportCenterService.java
+++ b/src/main/java/com/guideon/funds/service/SupportCenterService.java
@@ -1,0 +1,74 @@
+package com.guideon.funds.service;
+
+import com.guideon.funds.domain.SupportCenter;
+import com.guideon.funds.mapper.SupportCenterMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 지원센터 서비스
+ */
+@Service
+public class SupportCenterService {
+
+    
+    @Autowired
+    private SupportCenterMapper supportCenterMapper;
+    
+    /**
+     * 전체 지원센터 목록 조회
+     * @return 전체 지원센터 목록
+     */
+    public List<SupportCenter> getAllCenters() {
+        
+        List<SupportCenter> centers = supportCenterMapper.selectAllCenters();
+
+        return centers;
+    }
+    
+    /**
+     * 좌표가 있는 지원센터만 조회
+     * @return 좌표가 있는 지원센터 목록
+     */
+    public List<SupportCenter> getCentersWithCoordinates() {
+
+        List<SupportCenter> centers = supportCenterMapper.selectCentersWithCoordinates();
+        
+        return centers;
+    }
+    
+    /**
+     * ID로 지원센터 단건 조회
+     * @param id 지원센터 ID
+     * @return 지원센터 정보
+     */
+    public SupportCenter getCenterById(Long id) {
+        return supportCenterMapper.selectCenterById(id);
+    }
+    
+    /**
+     * 특정 관할구역의 지원센터 조회
+     * @param jurisdiction 관할구역
+     * @return 해당 관할구역의 지원센터 목록
+     */
+    public List<SupportCenter> getCentersByJurisdiction(String jurisdiction) {
+        return supportCenterMapper.selectCentersByJurisdiction(jurisdiction);
+    }
+    
+    /**
+     * 지원센터 좌표 업데이트
+     * @param supportCenter 업데이트할 지원센터 정보 (id, lat, lng 필수)
+     * @return 업데이트 성공 여부
+     */
+    public boolean updateCenterCoordinates(SupportCenter supportCenter) {
+        int updatedCount = supportCenterMapper.updateCenterCoordinates(supportCenter);
+        
+        boolean success = updatedCount > 0;
+        
+        return success;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.redis.ssl=false
 jwt.secret-key=${JWT_SECRET}
 
 guideon.security.dev-relaxed=true
+
+# kakao map api
+kakao.api.key=${KAKAO_API_KEY}

--- a/src/main/resources/com/guideon/funds/mapper/FundsMapper.xml
+++ b/src/main/resources/com/guideon/funds/mapper/FundsMapper.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.funds.mapper.FundsMapper">
+
+    <!-- ResultMap 정의 -->
+    <resultMap id="FundsVO" type="com.guideon.funds.domain.Funds">
+        <id property="id" column="id"/>
+        <result property="year" column="year"/>
+        <result property="categoryCode" column="category_code"/>
+        <result property="name" column="name"/>
+        <result property="status" column="status"/>
+        <result property="target" column="target"/>
+        <result property="purpose" column="purpose"/>
+        <result property="rate" column="rate"/>
+        <result property="term" column="term"/>
+        <result property="limitAmount" column="limit_amount"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <!-- 정책지원금 전체 목록 조회 -->
+    <select id="selectAllFunds" resultMap="FundsVO">
+        SELECT 
+            id, year, category_code, name, status, target, purpose,
+            rate, term, limit_amount, created_at, updated_at
+        FROM support_fund
+        ORDER BY created_at DESC
+    </select>
+
+    <!-- 정책지원금 상세 조회 -->
+    <select id="selectFundsById" parameterType="long" resultMap="FundsVO">
+        SELECT 
+            id, year, category_code, name, status, target, purpose,
+            rate, term, limit_amount, created_at, updated_at
+        FROM support_fund
+        WHERE id = #{id}
+    </select>
+
+    <!-- 정책지원금 이름으로 검색 -->
+    <select id="selectFundsByNameLike" parameterType="string" resultMap="FundsVO">
+        SELECT
+            id, year, category_code, name, status, target, purpose,
+            rate, term, limit_amount, created_at, updated_at
+        FROM support_fund
+        WHERE name LIKE CONCAT('%', #{keyword}, '%')
+        ORDER BY created_at DESC
+    </select>
+
+    <!-- 회원별 북마크된 정책지원금 ID 목록 조회 -->
+    <select id="selectSavedFundsIdsByMemberId" parameterType="long" resultType="long">
+        SELECT funds_id
+        FROM saved_funds
+        WHERE member_id = #{memberId}
+    </select>
+
+
+</mapper>

--- a/src/main/resources/com/guideon/funds/mapper/SavedFundsMapper.xml
+++ b/src/main/resources/com/guideon/funds/mapper/SavedFundsMapper.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.funds.mapper.SavedFundsMapper">
+
+    <!-- SavedFundsVO ResultMap -->
+    <resultMap id="SavedFundsVO" type="com.guideon.funds.domain.SavedFunds">
+        <id property="savedFundsId" column="saved_funds_id"/>
+        <result property="memberId" column="member_id"/>
+        <result property="fundsId" column="funds_id"/>
+        <result property="createdAt" column="created_at"/>
+        <association property="funds" javaType="com.guideon.funds.domain.Funds">
+            <id property="id" column="sf_id"/>
+            <result property="year" column="sf_year"/>
+            <result property="categoryCode" column="sf_category_code"/>
+            <result property="name" column="sf_name"/>
+            <result property="status" column="sf_status"/>
+            <result property="target" column="sf_target"/>
+            <result property="purpose" column="sf_purpose"/>
+            <result property="rate" column="sf_rate"/>
+            <result property="term" column="sf_term"/>
+            <result property="limitAmount" column="sf_limit_amount"/>
+            <result property="createdAt" column="sf_created_at"/>
+            <result property="updatedAt" column="sf_updated_at"/>
+        </association>
+    </resultMap>
+
+    <!-- 정책지원금 북마크 추가 -->
+    <insert id="insertSavedFunds">
+        INSERT INTO saved_funds (member_id, funds_id, created_at)
+        VALUES (#{memberId}, #{fundsId}, NOW())
+    </insert>
+
+    <!-- 정책지원금 북마크 해제 -->
+    <delete id="deleteSavedFunds">
+        DELETE FROM saved_funds 
+        WHERE member_id = #{memberId} 
+        AND funds_id = #{fundsId}
+    </delete>
+
+    <!-- 회원별 북마크한 정책지원금 목록 조회 (support_fund 정보 포함) -->
+    <select id="selectSavedFundsByMemberId" parameterType="long" resultMap="SavedFundsVO">
+        SELECT 
+            sf_saved.saved_funds_id,
+            sf_saved.member_id,
+            sf_saved.funds_id,
+            sf_saved.created_at,
+            sf.id AS sf_id,
+            sf.year AS sf_year,
+            sf.category_code AS sf_category_code,
+            sf.name AS sf_name,
+            sf.status AS sf_status,
+            sf.target AS sf_target,
+            sf.purpose AS sf_purpose,
+            sf.rate AS sf_rate,
+            sf.term AS sf_term,
+            sf.limit_amount AS sf_limit_amount,
+            sf.created_at AS sf_created_at,
+            sf.updated_at AS sf_updated_at
+        FROM saved_funds sf_saved
+        INNER JOIN support_fund sf ON sf_saved.funds_id = sf.id
+        WHERE sf_saved.member_id = #{memberId}
+        ORDER BY sf_saved.created_at DESC
+    </select>
+
+    <!-- 특정 회원의 특정 정책지원금 북마크 여부 확인 -->
+    <select id="existsSavedFunds" resultType="boolean">
+        SELECT COUNT(1) > 0
+        FROM saved_funds 
+        WHERE member_id = #{memberId} 
+        AND funds_id = #{fundsId}
+    </select>
+
+    <!-- 회원별 북마크 개수 -->
+    <select id="countSavedFundsByMemberId" parameterType="long" resultType="int">
+        SELECT COUNT(*)
+        FROM saved_funds sf_saved
+        INNER JOIN support_fund sf ON sf_saved.funds_id = sf.id
+        WHERE sf_saved.member_id = #{memberId}
+    </select>
+
+</mapper>

--- a/src/main/resources/com/guideon/funds/mapper/SupportCenterMapper.xml
+++ b/src/main/resources/com/guideon/funds/mapper/SupportCenterMapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.funds.mapper.SupportCenterMapper">
+
+    <!-- Result Map 정의 -->
+    <resultMap id="SupportCenterResultMap" type="com.guideon.funds.domain.SupportCenter">
+        <id property="id" column="id"/>
+        <result property="name" column="name"/>
+        <result property="jurisdiction" column="jurisdiction"/>
+        <result property="address" column="address"/>
+        <result property="phone" column="phone"/>
+        <result property="fax" column="fax"/>
+        <result property="lat" column="lat"/>
+        <result property="lng" column="lng"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <!-- 공통 컬럼 정의 -->
+    <sql id="selectColumns">
+        id, name, jurisdiction, address, phone, fax, lat, lng, created_at, updated_at
+    </sql>
+
+    <!-- 전체 지원센터 목록 조회 -->
+    <select id="selectAllCenters" resultMap="SupportCenterResultMap">
+        SELECT 
+            <include refid="selectColumns"/>
+        FROM support_center
+        ORDER BY name ASC
+    </select>
+
+    <!-- 좌표가 있는 지원센터만 조회 -->
+    <select id="selectCentersWithCoordinates" resultMap="SupportCenterResultMap">
+        SELECT 
+            <include refid="selectColumns"/>
+        FROM support_center
+        WHERE lat IS NOT NULL 
+          AND lng IS NOT NULL
+        ORDER BY name ASC
+    </select>
+
+    <!-- 특정 관할구역의 지원센터 조회 -->
+    <select id="selectCentersByJurisdiction" parameterType="String" resultMap="SupportCenterResultMap">
+        SELECT 
+            <include refid="selectColumns"/>
+        FROM support_center
+        WHERE jurisdiction LIKE CONCAT('%', #{jurisdiction}, '%')
+        ORDER BY name ASC
+    </select>
+
+    <!-- ID로 지원센터 단건 조회 -->
+    <select id="selectCenterById" parameterType="Long" resultMap="SupportCenterResultMap">
+        SELECT 
+            <include refid="selectColumns"/>
+        FROM support_center
+        WHERE id = #{id}
+    </select>
+
+    <!-- 지원센터 좌표 업데이트 -->
+    <update id="updateCenterCoordinates" parameterType="com.guideon.funds.domain.SupportCenter">
+        UPDATE support_center 
+        SET 
+            lat = #{lat},
+            lng = #{lng},
+            updated_at = NOW()
+        WHERE id = #{id}
+    </update>
+
+</mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
- 정책지원금 기본적인 CRUD, 북마크 기능
- LocalDateTime JSON 직렬화를 위한 Jackson 설정 추가
- 지원센터 위치 기반 검색 기능 및 API

## 📖 작업 내용 
- 정책지원금 기능을 구현하였습니다

### 크롤링
- Python을 이용하여 정책지원금 & 지역센터 크롤링 후 csv 파일로 변환 로직을 구현하였습니다.
- 해당 정보를 저장할 테이블하고, csv 데이터를 저장할 insert문을 작성하였습니다.

### 테이블 (notion > sql문)
`support_fund.sql` : 정책지원금 테이블 생성 및 데이터 insert문
`support_center.sql` : 지원센터 테이블 생성 및 데이터 isnert문
`saved_funds.sql` : 지원금 북마크 테이블 생성문

### API
- 정책지원금 전체 목록 조회, 상세조회, 이름 검색, 북마크(설정/해제/모아보기)
- 전체 센터 목록 조회, 가장 가까운 센터 찾기
- (백엔드) 개별/전체 센터 좌표 업데이트, 좌표있는 센터만 불러오기

### 추가 사항 (notion > 키 관련 문서)
kakao map api 사용으로 env파일에 key 관련 추가해놨습니다.

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
- closes #10 

