### PR TITLE
Feat : 마이데이터 연동 & 서류 상태 조회  & 서류 업로드 구현

### DIFF
--- a/src/main/java/com/guideon/config/ServletConfig.java
+++ b/src/main/java/com/guideon/config/ServletConfig.java
@@ -1,7 +1,10 @@
 package com.guideon.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -17,6 +20,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
         "com.guideon.funds"
 })
 public class ServletConfig implements WebMvcConfigurer {
+
+    /**
+     * Multipart 파일 업로드 처리를 위한 Resolver
+     */
+    @Bean
+    public MultipartResolver multipartResolver() {
+        StandardServletMultipartResolver resolver = new StandardServletMultipartResolver();
+        return resolver;
+    }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/src/main/java/com/guideon/config/WebConfig.java
+++ b/src/main/java/com/guideon/config/WebConfig.java
@@ -2,14 +2,19 @@ package com.guideon.config;
 
 import io.github.cdimascio.dotenv.Dotenv;
 import io.github.cdimascio.dotenv.DotenvBuilder;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
+
+import javax.servlet.*;
+
 import com.guideon.security.config.SecurityConfig;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
-import javax.servlet.Filter;
 
 public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitializer {
+
+    // 업로드 설정 상수
+    private static final long MAX_FILE_SIZE = 1024 * 1024 * 10L;      // 10MB (개별 파일)
+    private static final long MAX_REQUEST_SIZE = 1024 * 1024 * 15L;   // 15MB (전체 요청)
+    private static final int FILE_SIZE_THRESHOLD = 1024 * 1024 * 2;   // 2MB (메모리 임계값)
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
@@ -63,5 +68,25 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
         characterEncodingFilter.setForceEncoding(true);     // 응답 데이터도 UTF-8 강제 인코딩
 
         return new Filter[] { characterEncodingFilter };
+    }
+
+    @Override
+    protected void customizeRegistration(ServletRegistration.Dynamic registration) {
+        registration.setInitParameter("throwExceptionIfNoHandlerFound", "true");
+
+        registration.setInitParameter("allowCasualMultipartParsing", "true");
+
+        final String UPLOAD_LOCATION = System.getProperty("UPLOAD_BASE_PATH", "/tmp/uploads");
+
+        // 디버그 로그 추가
+        System.out.println("[UPLOAD] Using location: " + UPLOAD_LOCATION);
+
+        MultipartConfigElement multipartConfig = new MultipartConfigElement(
+                UPLOAD_LOCATION,        // 업로드 파일 임시 저장 디렉토리
+                MAX_FILE_SIZE,          // 개별 파일 최대 크기 (10MB)
+                MAX_REQUEST_SIZE,       // 전체 요청 최대 크기 (15MB)
+                FILE_SIZE_THRESHOLD     // 메모리 임계값 (2MB 이하는 메모리에서 처리)
+        );
+        registration.setMultipartConfig(multipartConfig);
     }
 }

--- a/src/main/java/com/guideon/document/controller/DocumentController.java
+++ b/src/main/java/com/guideon/document/controller/DocumentController.java
@@ -1,0 +1,88 @@
+package com.guideon.document.controller;
+
+import com.guideon.document.dto.SessionRequest;
+import com.guideon.document.service.DocumentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/document")
+@Log4j2
+public class DocumentController {
+
+    private final DocumentService documentService;
+
+    /**
+     * 대출 세션 생성
+     * 정책자금 선택 시 호출되어 새로운 대출 세션을 시작합니다.
+     */
+    @PostMapping("/sessions")
+    public ResponseEntity<Map<String, Object>> createLoanSession(
+            @RequestBody SessionRequest request) {
+
+        try {
+            log.info("대출 세션 생성 요청: businessId={}, policyId={}",
+                    request.getBusinessId(), request.getPolicyId());
+
+            Map<String, Object> result = documentService.createLoanSession(request);
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("success", true);
+            response.putAll(result);
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 요청: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", e.getMessage()
+            ));
+
+        } catch (Exception e) {
+            log.error("대출 세션 생성 중 오류 발생", e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "success", false,
+                    "message", "서버 오류가 발생했습니다."
+            ));
+        }
+    }
+
+    /**
+     * 세션별 필요 서류 목록 조회
+     */
+    @GetMapping("/required/{sessionId}")
+    public ResponseEntity<Map<String, Object>> getRequiredDocuments(
+            @PathVariable Long sessionId) {
+
+        try {
+            log.info("서류 목록 조회 요청: sessionId={}", sessionId);
+
+            Map<String, Object> result = documentService.getRequiredDocuments(sessionId);
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("success", true);
+            response.putAll(result);
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", e.getMessage()
+            ));
+
+        } catch (Exception e) {
+            log.error("서류 목록 조회 중 오류 발생: sessionId={}", sessionId, e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "success", false,
+                    "message", "서버 오류가 발생했습니다."
+            ));
+        }
+    }
+}

--- a/src/main/java/com/guideon/document/controller/DocumentController.java
+++ b/src/main/java/com/guideon/document/controller/DocumentController.java
@@ -100,4 +100,35 @@ public class DocumentController {
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * 서류 상태 조회
+     */
+    @GetMapping("/status/{sessionId}")
+    public ResponseEntity<Map<String, Object>> getDocumentStatus(@PathVariable Long sessionId) {
+
+        try {
+            log.info("서류 상태 조회 요청: sessionId={}", sessionId);
+
+            Map<String, Object> result = documentService.getDocumentStatus(sessionId);
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("success", true);
+            response.putAll(result);
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", e.getMessage()
+            ));
+
+        } catch (Exception e) {
+            log.error("서류 상태 조회 중 오류 발생: sessionId={}", sessionId, e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "success", false,
+                    "message", "서버 오류가 발생했습니다."
+            ));
+        }
+    }
 }

--- a/src/main/java/com/guideon/document/controller/DocumentController.java
+++ b/src/main/java/com/guideon/document/controller/DocumentController.java
@@ -131,4 +131,35 @@ public class DocumentController {
             ));
         }
     }
+
+    /**
+     * 파일 직접 업로드
+     */
+    @PostMapping("/upload/{sessionId}")
+    public ResponseEntity<Map<String, Object>> uploadFile(
+            @PathVariable Long sessionId,
+            @RequestPart("documentId") String documentIdStr,
+            @RequestPart("file") MultipartFile file) {
+
+        try {
+            Long documentId = Long.parseLong(documentIdStr);  // String을 Long으로 변환
+            log.info("파일 업로드 요청: sessionId={}, documentId={}", sessionId, documentId);
+
+            Map<String, Object> result = documentService.uploadFile(sessionId, documentId, file);
+            return ResponseEntity.ok(result);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "message", e.getMessage()
+            ));
+
+        } catch (Exception e) {
+            log.error("파일 업로드 중 오류 발생", e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "success", false,
+                    "message", "파일 업로드 중 오류가 발생했습니다."
+            ));
+        }
+    }
 }

--- a/src/main/java/com/guideon/document/controller/DocumentController.java
+++ b/src/main/java/com/guideon/document/controller/DocumentController.java
@@ -1,11 +1,13 @@
 package com.guideon.document.controller;
 
+import com.guideon.document.dto.MyDataSyncRequest;
 import com.guideon.document.dto.SessionRequest;
 import com.guideon.document.service.DocumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 
@@ -85,4 +87,17 @@ public class DocumentController {
             ));
         }
     }
+
+    /**
+     * 마이데이터 연동
+     */
+    @PostMapping("/mydata-sync/{sessionId}")
+    public ResponseEntity<Map<String, Object>> syncWithMyData(
+            @PathVariable Long sessionId,
+            @RequestBody MyDataSyncRequest request) {
+
+        Map<String, Object> result = documentService.syncWithMyData(sessionId, request);
+        return ResponseEntity.ok(result);
+    }
+
 }

--- a/src/main/java/com/guideon/document/controller/PolicyController.java
+++ b/src/main/java/com/guideon/document/controller/PolicyController.java
@@ -33,7 +33,7 @@ public class PolicyController {
 
             // 1. 소상공인 자격 판별
             if (!policyService.isSmallBusiness(businessId)) {
-                Map<String, Object> response = new HashMap<>();
+                Map<String, Object> response = new LinkedHashMap<>();
                 response.put("success", false);
                 response.put("isSmallBusiness", false);
                 response.put("message", "소상공인 자격 요건에 해당하지 않습니다.");
@@ -44,7 +44,7 @@ public class PolicyController {
             // 2. 정책자금 필터링
             List<PolicyDTO> eligiblePolicies = policyService.filterEligiblePolicies(businessId);
 
-            Map<String, Object> response = new HashMap<>();
+            Map<String, Object> response = new LinkedHashMap<>();
             response.put("success", true);
             response.put("isSmallBusiness", true);
             response.put("eligiblePolicies", eligiblePolicies);

--- a/src/main/java/com/guideon/document/controller/SurveyController.java
+++ b/src/main/java/com/guideon/document/controller/SurveyController.java
@@ -13,8 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @RestController
 @Log4j2
@@ -57,7 +56,7 @@ public class SurveyController {
             Long memberId = (Long) authInfo.get("memberId");
 
             // 2. 회원 정보에서 industryCode 조회 (현재는 임시값)
-            String industryCode = "56101";
+            String industryCode = "56111";
 
             // 3. BusinessInfoDTO 생성
             BusinessInfoDTO businessInfoDTO = BusinessInfoDTO.builder()
@@ -74,7 +73,7 @@ public class SurveyController {
             Long businessId = surveyService.saveUserSurvey(businessInfoDTO);
 
             // 5. 성공 응답
-            Map<String, Object> response = new HashMap<>();
+            Map<String, Object> response = new LinkedHashMap<>();
             response.put("success", true);
             response.put("message", "설문 응답이 저장되었습니다.");
             response.put("businessId", businessId);
@@ -83,7 +82,7 @@ public class SurveyController {
 
         } catch (Exception e) {
             // 6. 에러 응답
-            Map<String, Object> errorResponse = new HashMap<>();
+            Map<String, Object> errorResponse = new LinkedHashMap<>();
             errorResponse.put("success", false);
             errorResponse.put("message", "설문 응답 저장 중 오류가 발생했습니다: " + e.getMessage());
 

--- a/src/main/java/com/guideon/document/domain/DocumentUploadsVO.java
+++ b/src/main/java/com/guideon/document/domain/DocumentUploadsVO.java
@@ -1,0 +1,35 @@
+package com.guideon.document.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentUploadsVO {
+    private Long id;
+    private Long sessionId;
+    private String documentGroup;
+    private String documentName;    // 서류명
+    private Boolean isMydataAvailable;
+    private Boolean isMydataRetrieved;
+    private String originalFilename;
+    private String storedFilename;
+    private String filePath;
+    private Long fileSize;
+    private String mimeType;
+    private String uploadStatus;
+    private String validationResult;
+    private String errorMessage;
+
+    private Integer groupMinSelect; // 그룹 별 최소 개수
+    private Boolean isSelected; // 선택 여부 (필수 서류의 경우 모두 true)
+
+    private LocalDateTime uploadedAt;
+    private LocalDateTime validatedAt;
+
+
+}

--- a/src/main/java/com/guideon/document/domain/LoanSessionVO.java
+++ b/src/main/java/com/guideon/document/domain/LoanSessionVO.java
@@ -1,0 +1,26 @@
+package com.guideon.document.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoanSessionVO {
+    private Long id;                    // id
+    private Long businessId;            // 사업자 정보 아이디
+    private Long policyId;              // 정책자금 아이디
+    private String sessionStatus;       // 세션 상태
+    private Integer requiredDocuments;  // 필요 서류 수
+    private Integer submittedDocuments; // 제출 서류 수
+    private Integer validatedDocuments; // 검증 완료 서류 수
+    private BigDecimal progressPercentage; // 진행률
+    private Date createdAt;             // 생성시각
+    private Date updatedAt;             // 수정시각
+}

--- a/src/main/java/com/guideon/document/dto/DocumentSaveRequest.java
+++ b/src/main/java/com/guideon/document/dto/DocumentSaveRequest.java
@@ -1,0 +1,35 @@
+package com.guideon.document.dto;
+
+import com.guideon.document.domain.DocumentUploadsVO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DocumentSaveRequest {
+    private String documentGroup;      // 서류 그룹
+    private String documentName;       // 서류명
+    private Boolean isMydataAvailable; // 마이데이터 이용 여부
+    private Integer groupMinSelect;    // 그룹 최소 서류 수
+    private Boolean isSelected;        // 필수/선택 여부
+
+    /**
+     * DocumentUploadsVO로 변환
+     */
+    public DocumentUploadsVO toVO(Long sessionId) {
+        DocumentUploadsVO vo = new DocumentUploadsVO();
+        vo.setSessionId(sessionId);
+        vo.setDocumentGroup(documentGroup);
+        vo.setDocumentName(documentName);
+        vo.setIsMydataAvailable(isMydataAvailable);
+        vo.setIsMydataRetrieved(false);
+        vo.setGroupMinSelect(groupMinSelect);
+        vo.setIsSelected(isSelected);
+        vo.setUploadStatus("REQUIRED");
+        return vo;
+    }
+}

--- a/src/main/java/com/guideon/document/dto/FileUploadRequest.java
+++ b/src/main/java/com/guideon/document/dto/FileUploadRequest.java
@@ -1,0 +1,15 @@
+package com.guideon.document.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FileUploadRequest {
+    private Long documentId;        // 업로드할 서류 ID
+    private MultipartFile file;     // 업로드할 파일
+}

--- a/src/main/java/com/guideon/document/dto/LoanSessionDTO.java
+++ b/src/main/java/com/guideon/document/dto/LoanSessionDTO.java
@@ -1,0 +1,54 @@
+package com.guideon.document.dto;
+
+import com.guideon.document.domain.LoanSessionVO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoanSessionDTO {
+
+    private Long businessId;
+    private Long policyId;
+    private String sessionStatus;
+    private Integer requiredDocuments;
+    private Integer submittedDocuments;
+    private Integer validatedDocuments;
+    private BigDecimal progressPercentage;
+
+    /**
+     * DTO -> VO 변환
+     */
+    public LoanSessionVO toVO() {
+        return LoanSessionVO.builder()
+                .businessId(this.businessId)
+                .policyId(this.policyId)
+                .sessionStatus(this.sessionStatus)
+                .requiredDocuments(this.requiredDocuments)
+                .submittedDocuments(this.submittedDocuments)
+                .validatedDocuments(this.validatedDocuments)
+                .progressPercentage(this.progressPercentage)
+                .build();
+    }
+
+    /**
+     * 기본 세션 생성용 정적 메서드
+     */
+    public static LoanSessionDTO createDefault(Long businessId, Long policyId) {
+        return LoanSessionDTO.builder()
+                .businessId(businessId)
+                .policyId(policyId)
+                .sessionStatus("IN_PROGRESS")
+                .requiredDocuments(0)
+                .submittedDocuments(0)
+                .validatedDocuments(0)
+                .progressPercentage(BigDecimal.ZERO)
+                .build();
+    }
+}

--- a/src/main/java/com/guideon/document/dto/MyDataSyncRequest.java
+++ b/src/main/java/com/guideon/document/dto/MyDataSyncRequest.java
@@ -1,0 +1,29 @@
+package com.guideon.document.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyDataSyncRequest {
+
+    private List<Long> documentIds;
+    private MyDataAgreements agreements;
+
+    @Data
+    public static class MyDataAgreements {
+        private Boolean serviceTerms;
+        private Boolean privacyPolicy;
+        private Boolean thirdPartyConsent;
+
+        public boolean isAllAgreed() {
+            return Boolean.TRUE.equals(serviceTerms) &&
+                    Boolean.TRUE.equals(privacyPolicy) &&
+                    Boolean.TRUE.equals(thirdPartyConsent);
+        }
+    }
+}

--- a/src/main/java/com/guideon/document/dto/SessionRequest.java
+++ b/src/main/java/com/guideon/document/dto/SessionRequest.java
@@ -1,0 +1,13 @@
+package com.guideon.document.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SessionRequest {
+    private Long businessId;
+    private Long policyId;
+}

--- a/src/main/java/com/guideon/document/mapper/DocumentUploadsMapper.java
+++ b/src/main/java/com/guideon/document/mapper/DocumentUploadsMapper.java
@@ -1,0 +1,38 @@
+package com.guideon.document.mapper;
+
+import com.guideon.document.domain.DocumentUploadsVO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface DocumentUploadsMapper {
+
+    /**
+     * 서류 정보 저장
+     */
+    void insertDocuments(List<DocumentUploadsVO> documentUploads);
+
+    /**
+     * 세션별 서류 목록 조회
+     */
+    List<DocumentUploadsVO> selectBySessionId(Long sessionId);
+
+    /**
+     * 서류 업로드 상태 업데이트
+     */
+    void updateUploadStatus(DocumentUploadsVO documentUpload);
+
+    /**
+     * 세션별 마이데이터 연동 가능한 서류 ID 조회
+     */
+    List<Long> selectMydataEligibleIds(Long sessionId);
+
+    /**
+     * 마이데이터 연동 상태 업데이트
+     */
+    void updateMyDataStatus(List<Long> documentIds);
+
+
+}

--- a/src/main/java/com/guideon/document/mapper/DocumentUploadsMapper.java
+++ b/src/main/java/com/guideon/document/mapper/DocumentUploadsMapper.java
@@ -34,5 +34,19 @@ public interface DocumentUploadsMapper {
      */
     void updateMyDataStatus(List<Long> documentIds);
 
+    /**
+     * 서류 ID로 조회
+     */
+    DocumentUploadsVO selectById(Long documentId);
 
+    /**
+     * 파일 업로드 정보 업데이트
+     */
+    void updateFileInfo(@Param("documentId") Long documentId,
+                        @Param("originalFilename") String originalFilename,
+                        @Param("storedFilename") String storedFilename,
+                        @Param("filePath") String filePath,
+                        @Param("fileSize") Long fileSize,
+                        @Param("mimeType") String mimeType,
+                        @Param("uploadStatus") String uploadStatus);
 }

--- a/src/main/java/com/guideon/document/mapper/LoanSessionMapper.java
+++ b/src/main/java/com/guideon/document/mapper/LoanSessionMapper.java
@@ -1,0 +1,18 @@
+package com.guideon.document.mapper;
+
+import com.guideon.document.domain.LoanSessionVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface LoanSessionMapper {
+
+    /**
+     * 대출 세션 생성
+     */
+    int insert(LoanSessionVO loanSession);
+
+    /**
+     * 세션 ID로 조회
+     */
+    LoanSessionVO selectById(Long sessionId);
+}

--- a/src/main/java/com/guideon/document/mapper/LoanSessionMapper.java
+++ b/src/main/java/com/guideon/document/mapper/LoanSessionMapper.java
@@ -2,6 +2,7 @@ package com.guideon.document.mapper;
 
 import com.guideon.document.domain.LoanSessionVO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface LoanSessionMapper {
@@ -15,4 +16,12 @@ public interface LoanSessionMapper {
      * 세션 ID로 조회
      */
     LoanSessionVO selectById(Long sessionId);
+
+    /**
+     * 세션 진행 상태 업데이트
+     */
+    void updateSessionProgress(@Param("sessionId") Long sessionId,
+                               @Param("requiredDocuments") Integer requiredDocuments,
+                               @Param("submittedDocuments") Integer submittedDocuments,
+                               @Param("progressPercentage") Double progressPercentage);
 }

--- a/src/main/java/com/guideon/document/mapper/PolicyMapper.java
+++ b/src/main/java/com/guideon/document/mapper/PolicyMapper.java
@@ -12,4 +12,9 @@ public interface PolicyMapper {
      * 활성화된 정책자금 전체 조회
      */
     List<PolicyVO> selectActivePolicies();
+
+    /**
+     * 정책자금 ID로 단건 조회
+     */
+    PolicyVO selectByPolicyId(Long policyId);
 }

--- a/src/main/java/com/guideon/document/service/DocumentParsingService.java
+++ b/src/main/java/com/guideon/document/service/DocumentParsingService.java
@@ -1,0 +1,112 @@
+package com.guideon.document.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guideon.document.domain.BusinessInfoVO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * 정책자금별 필요 서류 JSON 파싱 및 처리 서비스
+ */
+@Service
+@Log4j2
+public class DocumentParsingService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * JSON 파싱해서 서류 그룹 목록 반환
+     *
+     * @param requiredDocumentsJson policies.required_documents JSON 문자열
+     * @param businessInfo 사용자 사업체 정보 (조건 평가용)
+     *
+     * @return 파싱된 서류 그룹 목록. 각 그룹은 groupKey, label, minSelect, documents 포함
+     *
+     * @throws RuntimeException JSON 파싱 실패 시
+     */
+    public List<Map<String, Object>> parseRequiredDocuments(String requiredDocumentsJson, BusinessInfoVO businessInfo) {
+        List<Map<String, Object>> documentGroups = new ArrayList<>();
+
+        try {
+            if (requiredDocumentsJson == null || requiredDocumentsJson.trim().isEmpty()) {
+                log.warn("required_documents JSON이 비어있습니다.");
+                return documentGroups;
+            }
+
+            // JSON 배열 파싱
+            List<Map<String, Object>> rawGroups = objectMapper.readValue(
+                    requiredDocumentsJson,
+                    new TypeReference<List<Map<String, Object>>>() {}
+            );
+
+            // 각 그룹을 처리
+            for (Map<String, Object> rawGroup : rawGroups) {
+                // trigger 조건 확인
+                String trigger = (String) rawGroup.get("trigger");
+                if (!evaluateTriggerCondition(trigger, businessInfo)) {
+                    continue; // 조건에 맞지 않으면 스킵
+                }
+
+                // 그룹 정보 구성
+                Map<String, Object> group = new LinkedHashMap<>();
+                group.put("groupKey", rawGroup.get("group_key"));
+                group.put("label", rawGroup.get("label"));
+                group.put("minSelect", rawGroup.get("min_select"));
+                group.put("description", rawGroup.get("description"));
+
+                // 서류 목록 처리
+                List<Map<String, Object>> docs = (List<Map<String, Object>>) rawGroup.get("docs");
+                List<Map<String, Object>> processedDocs = new ArrayList<>();
+
+                if (docs != null) {
+                    for (Map<String, Object> doc : docs) {
+                        Map<String, Object> processedDoc = new LinkedHashMap<>();
+                        processedDoc.put("name", doc.get("name"));
+                        processedDoc.put("mydataEligible", doc.get("mydata_eligible"));
+                        processedDoc.put("status", "pending"); // 초기 상태
+                        processedDocs.add(processedDoc);
+                    }
+                }
+
+                group.put("documents", processedDocs);
+                documentGroups.add(group);
+            }
+
+        } catch (Exception e) {
+            log.error("JSON 파싱 실패: {}", requiredDocumentsJson, e);
+            throw new RuntimeException("서류 목록 파싱 중 오류가 발생했습니다.");
+        }
+
+        return documentGroups;
+    }
+
+    /**
+     * trigger 조건 평가
+     */
+    public boolean evaluateTriggerCondition(String trigger, BusinessInfoVO businessInfo) {
+        if (trigger == null || trigger.trim().isEmpty()) {
+            return true; // trigger가 없으면 항상 포함
+        }
+
+        // 1. 상시근로자 유뮤 서류 체크
+        // "user.employees == 0" 형태의 조건 평가
+        if (trigger.contains("user.employees == 0")) {
+            return businessInfo.getEmployees() == 0;
+        }
+        if (trigger.contains("user.employees > 0")) {
+            return businessInfo.getEmployees() > 0;
+        }
+
+        // 2. 청년 조건
+        if (trigger.contains("user.business_period >= 36 OR user.age > 39")) {
+            // 현재는 업력만 체크 (나이는 나중에 처리)
+            return businessInfo.getBusinessPeriod() >= 36;
+        }
+
+        // 기본적으로 true 반환 (알 수 없는 조건)
+        return true;
+    }
+}

--- a/src/main/java/com/guideon/document/service/DocumentService.java
+++ b/src/main/java/com/guideon/document/service/DocumentService.java
@@ -1,0 +1,20 @@
+package com.guideon.document.service;
+
+import com.guideon.document.dto.SessionRequest;
+
+import java.util.Map;
+
+public interface DocumentService {
+
+    /**
+     * 대출 세션 생성
+     * @param request businessId, policyId 포함
+     * @return 생성된 세션 정보
+     */
+    Map<String, Object> createLoanSession(SessionRequest request);
+
+    /**
+     * 세션별 필요 서류 목록 조회
+     */
+    Map<String, Object> getRequiredDocuments(Long sessionId);
+}

--- a/src/main/java/com/guideon/document/service/DocumentService.java
+++ b/src/main/java/com/guideon/document/service/DocumentService.java
@@ -1,8 +1,10 @@
 package com.guideon.document.service;
 
+import com.guideon.document.dto.MyDataSyncRequest;
 import com.guideon.document.dto.SessionRequest;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Map;
+import java.util.*;
 
 public interface DocumentService {
 
@@ -15,6 +17,16 @@ public interface DocumentService {
 
     /**
      * 세션별 필요 서류 목록 조회
+     * @param sessionId 세션 아이디
+     * @return 해당 세션에 대한 필요 서류
      */
     Map<String, Object> getRequiredDocuments(Long sessionId);
+
+    /**
+     * 마이데이터 연동
+     * @param sessionId 세션 아이디
+     * @param request 마이데이터 연동 동의 여부
+     * @return 업데이트된 서류 정보
+     */
+    Map<String, Object> syncWithMyData(Long sessionId, MyDataSyncRequest request);
 }

--- a/src/main/java/com/guideon/document/service/DocumentService.java
+++ b/src/main/java/com/guideon/document/service/DocumentService.java
@@ -37,4 +37,8 @@ public interface DocumentService {
      */
     Map<String, Object> getDocumentStatus(Long sessionId);
 
+    /**
+     * 파일 직접 업로드
+     */
+    Map<String, Object> uploadFile(Long sessionId, Long documentId, MultipartFile file);
 }

--- a/src/main/java/com/guideon/document/service/DocumentService.java
+++ b/src/main/java/com/guideon/document/service/DocumentService.java
@@ -29,4 +29,12 @@ public interface DocumentService {
      * @return 업데이트된 서류 정보
      */
     Map<String, Object> syncWithMyData(Long sessionId, MyDataSyncRequest request);
+
+    /**
+     * 서류 상태 조회
+     * @param sessionId 세션 아이디
+     * @return 서류 제출 상태
+     */
+    Map<String, Object> getDocumentStatus(Long sessionId);
+
 }

--- a/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
@@ -1,0 +1,107 @@
+package com.guideon.document.service;
+
+import com.guideon.document.domain.BusinessInfoVO;
+import com.guideon.document.domain.LoanSessionVO;
+import com.guideon.document.domain.PolicyVO;
+import com.guideon.document.dto.LoanSessionDTO;
+import com.guideon.document.dto.SessionRequest;
+import com.guideon.document.mapper.BusinessInfoMapper;
+import com.guideon.document.mapper.LoanSessionMapper;
+import com.guideon.document.mapper.PolicyMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class DocumentServiceImpl implements DocumentService {
+
+    private final BusinessInfoMapper businessInfoMapper;
+    private final PolicyMapper policyMapper;
+    private final LoanSessionMapper loanSessionMapper;
+    private final DocumentParsingService documentParsingService;
+
+    @Override
+    public Map<String, Object> createLoanSession(SessionRequest request) {
+
+        log.info("대출 세션 생성 시작: businessId={}, policyId={}",
+                request.getBusinessId(), request.getPolicyId());
+
+        // 1. 사업체 정보 유효성 검증
+        BusinessInfoVO businessInfo = businessInfoMapper.selectByBusinessId(request.getBusinessId());
+        if (businessInfo == null) {
+            throw new IllegalArgumentException("존재하지 않는 사업체 정보입니다. businessId: " + request.getBusinessId());
+        }
+
+        // 2. 정책자금 유효성 검증
+        PolicyVO policy = policyMapper.selectByPolicyId(request.getPolicyId());
+        if (policy == null) {
+            throw new IllegalArgumentException("존재하지 않는 정책자금입니다. policyId: " + request.getPolicyId());
+        }
+
+        // 3. 실제 세션 생성
+        LoanSessionDTO sessionDTO = LoanSessionDTO.createDefault(
+                request.getBusinessId(),
+                request.getPolicyId()
+        );
+
+        LoanSessionVO loanSession = sessionDTO.toVO();
+        loanSessionMapper.insert(loanSession);
+        Long sessionId = loanSession.getId();
+
+        // 4. 응답 구성
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("sessionId", sessionId);
+        response.put("businessId", request.getBusinessId());
+        response.put("policyId", request.getPolicyId());
+        response.put("sessionStatus", "IN_PROGRESS");
+        response.put("requiredDocuments", 0);
+        response.put("submittedDocuments", 0);
+        response.put("progressPercentage", 0.0);
+
+        log.info("대출 세션 생성 완료: sessionId={}", sessionId);
+
+        return response;
+    }
+    @Override
+    public Map<String, Object> getRequiredDocuments(Long sessionId) {
+
+        log.info("서류 목록 조회 시작: sessionId={}", sessionId);
+
+        // 1. 세션 정보 조회
+        LoanSessionVO session = loanSessionMapper.selectById(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("존재하지 않는 세션입니다. sessionId: " + sessionId);
+        }
+
+        // 2. 정책자금 정보 조회
+        PolicyVO policy = policyMapper.selectByPolicyId(session.getPolicyId());
+        if (policy == null) {
+            throw new IllegalArgumentException("정책자금 정보를 찾을 수 없습니다.");
+        }
+
+        // 3. 사업체 정보 조회
+        BusinessInfoVO businessInfo = businessInfoMapper.selectByBusinessId(session.getBusinessId());
+        if (businessInfo == null) {
+            throw new IllegalArgumentException("사업체 정보를 찾을 수 없습니다.");
+        }
+
+        // 4. DocumentParsingService로 JSON 파싱
+        List<Map<String, Object>> documentGroups = documentParsingService.parseRequiredDocuments(
+            policy.getRequiredDocuments(), 
+            businessInfo
+        );
+
+        // 5. 응답 구성 (순서 보장)
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("sessionId", sessionId);
+        response.put("policyName", policy.getPolicyName());
+        response.put("documentGroups", documentGroups);
+        response.put("totalGroups", documentGroups.size());
+
+        return response;
+    }
+}

--- a/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
@@ -1,18 +1,26 @@
 package com.guideon.document.service;
 
 import com.guideon.document.domain.BusinessInfoVO;
+import com.guideon.document.domain.DocumentUploadsVO;
 import com.guideon.document.domain.LoanSessionVO;
 import com.guideon.document.domain.PolicyVO;
+import com.guideon.document.dto.DocumentSaveRequest;
 import com.guideon.document.dto.LoanSessionDTO;
+import com.guideon.document.dto.MyDataSyncRequest;
 import com.guideon.document.dto.SessionRequest;
 import com.guideon.document.mapper.BusinessInfoMapper;
+import com.guideon.document.mapper.DocumentUploadsMapper;
 import com.guideon.document.mapper.LoanSessionMapper;
 import com.guideon.document.mapper.PolicyMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +31,8 @@ public class DocumentServiceImpl implements DocumentService {
     private final PolicyMapper policyMapper;
     private final LoanSessionMapper loanSessionMapper;
     private final DocumentParsingService documentParsingService;
+    private final DocumentUploadsMapper documentUploadsMapper;
+
 
     @Override
     public Map<String, Object> createLoanSession(SessionRequest request) {
@@ -95,6 +105,15 @@ public class DocumentServiceImpl implements DocumentService {
             businessInfo
         );
 
+        // 5. 서류 정보를 DB에 저장 (중복 체크)
+        List<DocumentUploadsVO> existingDocs = documentUploadsMapper.selectBySessionId(sessionId);
+        if (existingDocs.isEmpty()) {
+            saveDocuments(sessionId, documentGroups);
+            log.info("서류 정보 저장 완료: sessionId={}", sessionId);
+        } else {
+            log.info("이미 저장된 서류 목록 존재: sessionId={}, 기존 서류 수={}", sessionId, existingDocs.size());
+        }
+
         // 5. 응답 구성 (순서 보장)
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("sessionId", sessionId);
@@ -103,5 +122,75 @@ public class DocumentServiceImpl implements DocumentService {
         response.put("totalGroups", documentGroups.size());
 
         return response;
+    }
+
+    @Override
+    public Map<String, Object> syncWithMyData(Long sessionId, MyDataSyncRequest request) {
+
+        log.info("마이데이터 연동 시작: sessionId={}", sessionId);
+
+        // 1. 약관 동의 검증
+        if (request.getAgreements() == null || !request.getAgreements().isAllAgreed()) {
+            throw new IllegalArgumentException("마이데이터 이용을 위해서는 모든 약관에 동의해야 합니다.");
+        }
+
+        // 2. 세션 검증
+        LoanSessionVO session = loanSessionMapper.selectById(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("존재하지 않는 세션입니다.");
+        }
+
+        // 3. 마이데이터 연동 가능한 서류들 조회
+        List<Long> mydataEligibleIds = documentUploadsMapper.selectMydataEligibleIds(sessionId);
+
+        if (mydataEligibleIds.isEmpty()) {
+            throw new IllegalArgumentException("마이데이터 연동 가능한 서류가 없습니다.");
+        }
+
+        // 4. 마이데이터 연동 처리
+        documentUploadsMapper.updateMyDataStatus(mydataEligibleIds);
+
+        // 5. 응답
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("sessionId", sessionId);
+        response.put("syncedDocuments", mydataEligibleIds.size());
+        response.put("message", "마이데이터 연동이 완료되었습니다.");
+
+        log.info("마이데이터 연동 완료: sessionId={}, 연동된 서류 수={}", sessionId, mydataEligibleIds.size());
+
+        return response;
+    }
+
+    /**
+     * 파싱된 서류 정보를 DB에 저장
+     */
+    private void saveDocuments(Long sessionId, List<Map<String, Object>> documentGroups) {
+
+        List<DocumentUploadsVO> documentUploads = new ArrayList<>();
+
+        for (Map<String, Object> group : documentGroups) {
+            String groupKey = (String) group.get("groupKey");
+            Integer minSelect = (Integer) group.get("minSelect");
+            List<Map<String, Object>> docs = (List<Map<String, Object>>) group.get("documents");
+
+            if (docs != null) {
+                for (Map<String, Object> doc : docs) {
+                    DocumentSaveRequest request = DocumentSaveRequest.builder()
+                            .documentGroup(groupKey)
+                            .documentName((String) doc.get("name"))
+                            .isMydataAvailable((Boolean) doc.get("mydataEligible"))
+                            .groupMinSelect(minSelect)
+                            .isSelected(minSelect != 1)  // 택1이면 false, 나머지 true
+                            .build();
+
+                    documentUploads.add(request.toVO(sessionId));
+                }
+            }
+        }
+
+        if (!documentUploads.isEmpty()) {
+            documentUploadsMapper.insertDocuments(documentUploads);
+            log.info("서류 정보 저장 완료: sessionId={}, 저장된 서류 수={}", sessionId, documentUploads.size());
+        }
     }
 }

--- a/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
@@ -256,6 +256,102 @@ public class DocumentServiceImpl implements DocumentService {
         return response;
     }
 
+    @Override
+    public Map<String, Object> uploadFile(Long sessionId, Long documentId, MultipartFile file) {
+
+        log.info("파일 업로드 시작: sessionId={}, documentId={}, filename={}",
+                sessionId, documentId, file.getOriginalFilename());
+
+        // 1. 세션 검증
+        LoanSessionVO session = loanSessionMapper.selectById(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("존재하지 않는 세션입니다. sessionId: " + sessionId);
+        }
+
+        // 2. 서류 정보 검증
+        DocumentUploadsVO document = documentUploadsMapper.selectById(documentId);
+        if (document == null) {
+            throw new IllegalArgumentException("존재하지 않는 서류입니다. documentId: " + documentId);
+        }
+
+        if (!document.getSessionId().equals(sessionId)) {
+            throw new IllegalArgumentException("해당 세션에 속하지 않는 서류입니다.");
+        }
+
+        // 3. 파일 검증
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+
+        // 4. 파일 저장 처리
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String storedFilename = generateStoredFilename(originalFilename);
+            String filePath = saveFile(file, storedFilename);
+
+            // 5. 데이터베이스 업데이트
+            documentUploadsMapper.updateFileInfo(
+                    documentId,
+                    originalFilename,
+                    storedFilename,
+                    filePath,
+                    file.getSize(),
+                    file.getContentType(),
+                    "UPLOADED"
+            );
+
+            // 6. 응답 구성
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("success", true);
+            response.put("documentId", documentId);
+            response.put("documentName", document.getDocumentName());
+            response.put("originalFilename", originalFilename);
+            response.put("fileSize", file.getSize());
+            response.put("uploadStatus", "UPLOADED");
+            response.put("message", "파일 업로드가 완료되었습니다.");
+
+            log.info("파일 업로드 완료: documentId={}, filename={}", documentId, originalFilename);
+
+            return response;
+
+        } catch (Exception e) {
+            log.error("파일 업로드 실패: documentId={}, filename={}", documentId, file.getOriginalFilename(), e);
+            throw new RuntimeException("파일 업로드 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 저장용 파일명 생성 (중복 방지)
+     */
+    private String generateStoredFilename(String originalFilename) {
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        return System.currentTimeMillis() + "_" + UUID.randomUUID().toString().substring(0, 8) + extension;
+    }
+
+    /**
+     * 파일 저장 (실제 파일 시스템에 저장)
+     */
+    private String saveFile(MultipartFile file, String storedFilename) throws IOException {
+        // 환경변수에서 업로드 경로 읽기
+        String uploadBase = System.getProperty("UPLOAD_BASE_PATH", "/tmp/uploads");
+        String uploadDir = uploadBase + "/documents/";
+
+        File dir = new File(uploadDir);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        String filePath = uploadDir + storedFilename;
+        File targetFile = new File(filePath);
+        file.transferTo(targetFile);
+
+        return filePath;
+    }
+
+
     /**
      * 파싱된 서류 정보를 DB에 저장
      */

--- a/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
@@ -161,6 +161,101 @@ public class DocumentServiceImpl implements DocumentService {
         return response;
     }
 
+    @Override
+    public Map<String, Object> getDocumentStatus(Long sessionId) {
+
+        log.info("서류 상태 조회 시작: sessionId={}", sessionId);
+
+        // 1. 세션 검증
+        LoanSessionVO session = loanSessionMapper.selectById(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("존재하지 않는 세션입니다. sessionId: " + sessionId);
+        }
+
+        // 2. 해당 세션의 모든 서류 조회
+        List<DocumentUploadsVO> documents = documentUploadsMapper.selectBySessionId(sessionId);
+
+        // 3. 그룹별로 서류 분류
+        Map<String, List<DocumentUploadsVO>> groupedDocuments = documents.stream()
+                .collect(Collectors.groupingBy(DocumentUploadsVO::getDocumentGroup));
+
+        // 4. 그룹별 상태 계산
+        List<Map<String, Object>> groupStatus = new ArrayList<>();
+        int totalRequirements = 0;
+        int completedRequirements = 0;
+
+        for (Map.Entry<String, List<DocumentUploadsVO>> entry : groupedDocuments.entrySet()) {
+            String groupKey = entry.getKey();
+            List<DocumentUploadsVO> groupDocs = entry.getValue();
+
+            // 그룹 정보 (첫 번째 서류에서 추출)
+            DocumentUploadsVO firstDoc = groupDocs.get(0);
+            Integer minSelect = firstDoc.getGroupMinSelect();
+
+            // 실제 제출된 서류 수 계산
+            int actualSubmittedCount = (int) groupDocs.stream()
+                    .filter(doc -> "UPLOADED".equals(doc.getUploadStatus()) || "VALIDATED".equals(doc.getUploadStatus()))
+                    .count();
+
+            // 표시용 제출 수 (택1 그룹은 minSelect로 제한)
+            int displaySubmittedCount = Math.min(actualSubmittedCount, minSelect);
+
+            // 그룹 완료 여부
+            boolean isCompleted = actualSubmittedCount >= minSelect;
+
+            // 진행률 계산을 위한 카운트
+            totalRequirements += minSelect;
+            if (isCompleted) {
+                completedRequirements += minSelect;
+            } else {
+                completedRequirements += displaySubmittedCount;
+            }
+
+            // 서류별 상세 정보
+            List<Map<String, Object>> documentDetails = groupDocs.stream()
+                    .map(doc -> {
+                        Map<String, Object> detail = new LinkedHashMap<>();
+                        detail.put("id", doc.getId());
+                        detail.put("documentName", doc.getDocumentName());
+                        detail.put("uploadStatus", doc.getUploadStatus());
+                        detail.put("isSelected", doc.getIsSelected());
+                        detail.put("isMydataRetrieved", doc.getIsMydataRetrieved());
+                        detail.put("isMydataAvailable", doc.getIsMydataAvailable());
+                        return detail;
+                    })
+                    .toList();
+
+            // 그룹 상태 정보
+            Map<String, Object> groupInfo = new LinkedHashMap<>();
+            groupInfo.put("groupKey", groupKey);
+            groupInfo.put("minSelect", minSelect);
+            groupInfo.put("submitted", displaySubmittedCount);  // 조정된 제출 수
+            groupInfo.put("isCompleted", isCompleted);
+            groupInfo.put("documents", documentDetails);
+
+            groupStatus.add(groupInfo);
+        }
+
+        // 5. 전체 진행률 계산
+        double progressPercentage = totalRequirements > 0 ?
+                Math.round((double) completedRequirements / totalRequirements * 100.0 * 100.0) / 100.0 : 0.0;
+
+        // 6. 응답 구성
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("sessionId", sessionId);
+        response.put("totalRequirements", totalRequirements);
+        response.put("completedRequirements", completedRequirements);
+        response.put("progressPercentage", progressPercentage);
+        response.put("groupStatus", groupStatus);
+
+        // 7. loan_sessions 테이블 업데이트 추가
+        loanSessionMapper.updateSessionProgress(sessionId, totalRequirements, completedRequirements, progressPercentage);
+
+        log.info("서류 상태 조회 완료: sessionId={}, 진행률={}%", sessionId, progressPercentage);
+
+        return response;
+    }
+
     /**
      * 파싱된 서류 정보를 DB에 저장
      */

--- a/src/main/resources/com/guideon/document/mapper/DocumentUploadsMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/DocumentUploadsMapper.xml
@@ -54,5 +54,24 @@
         </foreach>
     </update>
 
+    <!-- 서류 ID로 조회 -->
+    <select id="selectById" parameterType="Long" resultType="DocumentUploadsVO">
+        SELECT * FROM document_uploads
+        WHERE id = #{documentId}
+    </select>
+
+    <!-- 파일 업로드 정보 업데이트 -->
+    <update id="updateFileInfo">
+        UPDATE document_uploads
+        SET original_filename = #{originalFilename},
+            stored_filename = #{storedFilename},
+            file_path = #{filePath},
+            file_size = #{fileSize},
+            mime_type = #{mimeType},
+            upload_status = #{uploadStatus},
+            is_selected = true,
+            uploaded_at = NOW()
+        WHERE id = #{documentId}
+    </update>
 
 </mapper>

--- a/src/main/resources/com/guideon/document/mapper/DocumentUploadsMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/DocumentUploadsMapper.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.document.mapper.DocumentUploadsMapper">
+
+    <!-- 서류 정보 저장 -->
+    <insert id="insertDocuments" parameterType="java.util.List">
+        INSERT INTO document_uploads (
+        session_id, document_group, document_name,
+        is_mydata_available, is_mydata_retrieved, group_min_select, is_selected, upload_status
+        ) VALUES
+        <foreach collection="list" item="doc" separator=",">
+            (#{doc.sessionId}, #{doc.documentGroup}, #{doc.documentName},
+            #{doc.isMydataAvailable}, #{doc.isMydataRetrieved}, #{doc.groupMinSelect}, #{doc.isSelected}, #{doc.uploadStatus})
+        </foreach>
+    </insert>
+
+    <!-- 세션별 서류 목록 조회 -->
+    <select id="selectBySessionId" parameterType="Long" resultType="DocumentUploadsVO">
+        SELECT * FROM document_uploads
+        WHERE session_id = #{sessionId}
+        ORDER BY id
+    </select>
+
+    <!-- 서류 업로드 상태 업데이트 -->
+    <update id="updateUploadStatus" parameterType="DocumentUploadsVO">
+        UPDATE document_uploads
+        SET upload_status = #{uploadStatus},
+            uploaded_at = #{uploadedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- 세션별 마이데이터 연동 가능한 서류 ID 조회 -->
+    <select id="selectMydataEligibleIds" parameterType="Long" resultType="Long">
+        SELECT id
+        FROM document_uploads
+        WHERE session_id = #{sessionId}
+          AND is_mydata_available = true
+        ORDER BY id
+    </select>
+
+    <!-- 마이데이터 연동 상태 업데이트 -->
+    <update id="updateMyDataStatus" parameterType="java.util.List">
+        UPDATE document_uploads
+        SET is_mydata_retrieved = true,
+        upload_status = 'UPLOADED',
+        is_selected = true,
+        uploaded_at = NOW()
+        WHERE id IN
+        <foreach collection="list" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </update>
+
+
+</mapper>

--- a/src/main/resources/com/guideon/document/mapper/LoanSessionMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/LoanSessionMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.guideon.document.mapper.LoanSessionMapper">
+
+    <!-- 대출 세션 생성 -->
+    <insert id="insert" parameterType="LoanSessionVO" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO loan_sessions (
+            business_id,
+            policy_id,
+            session_status,
+            required_documents,
+            submitted_documents,
+            validated_documents,
+            progress_percentage
+        ) VALUES (
+                     #{businessId},
+                     #{policyId},
+                     #{sessionStatus},
+                     #{requiredDocuments},
+                     #{submittedDocuments},
+                     #{validatedDocuments},
+                     #{progressPercentage}
+                 )
+    </insert>
+
+    <!-- 세션 ID로 조회 -->
+    <select id="selectById" parameterType="long" resultType="LoanSessionVO">
+        SELECT
+            id,
+            business_id as businessId,
+            policy_id as policyId,
+            session_status as sessionStatus,
+            required_documents as requiredDocuments,
+            submitted_documents as submittedDocuments,
+            validated_documents as validatedDocuments,
+            progress_percentage as progressPercentage,
+            created_at as createdAt,
+            updated_at as updatedAt
+        FROM loan_sessions
+        WHERE id = #{sessionId}
+    </select>
+
+</mapper>

--- a/src/main/resources/com/guideon/document/mapper/LoanSessionMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/LoanSessionMapper.xml
@@ -43,4 +43,13 @@
         WHERE id = #{sessionId}
     </select>
 
+    <!-- 세션 진행 상태 업데이트 -->
+    <update id="updateSessionProgress">
+        UPDATE loan_sessions
+        SET required_documents = #{requiredDocuments},
+            submitted_documents = #{submittedDocuments},
+            progress_percentage = #{progressPercentage},
+            updated_at = NOW()
+        WHERE id = #{sessionId}
+    </update>
 </mapper>

--- a/src/main/resources/com/guideon/document/mapper/PolicyMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/PolicyMapper.xml
@@ -35,4 +35,33 @@
         ORDER BY policy_id
     </select>
 
+    <!-- 정책자금 ID로 단건 조회 -->
+    <select id="selectByPolicyId" parameterType="long" resultType="PolicyVO">
+        SELECT
+            policy_id as policyId,
+            policy_name as policyName,
+            policy_type as policyType,
+            loan_purpose as loanPurpose,
+            min_business_period as minBusinessPeriod,
+            max_business_period as maxBusinessPeriod,
+            min_revenue as minRevenue,
+            max_revenue as maxRevenue,
+            required_documents as requiredDocuments,
+            special_conditions as specialConditions,
+            loan_limit as loanLimit,
+            term_years as termYears,
+            grace_years as graceYears,
+            quarter,
+            base_rate as baseRate,
+            spread_pp as spreadPp,
+            rate_type as rateType,
+            max_discount as maxDiscount,
+            discount_rules as discountRules,
+            is_active as isActive,
+            created_at as createdAt,
+            updated_at as updatedAt
+        FROM policies
+        WHERE policy_id = #{policyId}
+          AND is_active = 1
+    </select>
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
1. 마이데이터 연동을 통한 서류 자동 제출 기능 구현
2. 서류 등록 상태 조회 및 진행률 계산 기능 구현  
3. 서류 파일 직접 업로드 기능 구현
- 파일 업로드 환경 설정 및 MultipartConfig 구성 완료
- 서류별 그룹 관리 및 진행률 계산 로직 구현

## 📖 작업 내용 

**🗄️ 데이터베이스 설계**
- `document_uploads` 테이블 활용: 세션별 서류 목록 관리 및 업로드 상태 추적
- 서류 그룹별 진행률 계산: `group_min_select` 기반 택1/택N 그룹 처리
- loan_sessions에서 진행률, 서류 등록 상태 확인 가능
- 개별 서류 등록상태 확인은 document_uploads에서 확인
- 마이데이터 연동 상태 필드: `is_mydata_retrieved`, `is_mydata_available` 관리

**🏗️ 도메인 객체 및 DTO 구현**
- DTO 클래스: `MyDataSyncRequest`, `FileUploadRequest` (마이데이터 연동 요청, 파일 업로드 요청)
- 약관 동의 검증 로직: 마이데이터 이용 약관 전체 동의 확인

**🎯 비즈니스 로직 구현**
- 마이데이터 연동 서비스: 연동 가능한 서류 자동 처리 및 상태 업데이트
- 서류 상태 조회: 그룹별 완료 상태 계산 및 전체 진행률 산출
- 파일 업로드 처리: 파일 검증, 저장, DB 업데이트 로직
- 파일명 중복 방지: 타임스탬프 + UUID 기반 저장 파일명 생성

**🌐 API 엔드포인트 구현**
- 마이데이터 연동: `POST /api/document/mydata-sync/{sessionId}` - 약관 동의 후 자동 서류 연동
- 서류 상태 조회: `GET /api/document/status/{sessionId}` - 그룹별 진행 상태 및 전체 진행률 반환
- 파일 업로드: `POST /api/document/upload/{sessionId}` - 개별 서류 파일 업로드

**⚙️ 환경 설정 변경**
1. `.env` 파일 추가: `UPLOAD_BASE_PATH=/Users/swj/uploads` 파일 업로드 경로 설정
2. `WebConfig.java` 수정:
  - MultipartConfigElement 설정 (파일 크기: 개별 10MB, 전체 15MB)
  - `allowCasualMultipartParsing` 옵션 활성화
  - 환경변수 기반 업로드 경로 동적 설정

**🧪 테스트 결과**
- 마이데이터 연동 시 대상 서류 자동 업데이트 확인 (`200 OK`)
- 서류 상태 조회 시 그룹별 진행률 정확한 계산 확인 (`200 OK`)
- 파일 업로드 시 올바른 경로 저장 및 DB 업데이트 확인 (`200 OK`)

**서류 전체 로직 테스트 순서**
- 사업정보 입력 (사전 설문) -> 맞춤형 정책자금 조회 -> 대출 세션 생성 -> 필요 서류 목록 조회 -> 마이데이터 연동 -> 서류 상태 조회 -> 파일 직접 업로드
- 자세한 내용은 Notion API명세서 참고

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 환경 설정 변경사항 문서화 완료
- [x] 관련 이슈가 있다면 연결했습니다.

## ✋ 질문 사항
- 파일 업로드 경로 `/Users/swj/uploads`는 개발 환경 기준이므로, 운영 환경 배포 시 경로 변경 필요
- 현재 모든 파일 형식을 허용하고 있는데, 보안상 특정 확장자 제한이 필요한지 검토 요청

## 🔗 관련 이슈
- closes #17 