### PR TITLE
feat: 세션 생성 시 결과 생성, 파일 업로드 시 진행률 즉시 반영 구현

### DIFF
--- a/src/main/java/com/guideon/document/controller/DocumentController.java
+++ b/src/main/java/com/guideon/document/controller/DocumentController.java
@@ -1,8 +1,10 @@
 package com.guideon.document.controller;
 
+import com.guideon.document.dto.DocumentResultDTO;
 import com.guideon.document.dto.MyDataSyncRequest;
 import com.guideon.document.dto.SessionRequest;
 import com.guideon.document.service.DocumentService;
+import com.guideon.document.service.LoanSessionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import java.util.*;
 public class DocumentController {
 
     private final DocumentService documentService;
+    private final LoanSessionService loanSessionService;
 
     /**
      * 세션별 필요 서류 목록 조회
@@ -66,6 +69,10 @@ public class DocumentController {
 
             Map<String, Object> result = documentService.syncWithMyData(sessionId, request);
 
+            // 연동 완료 시에 결과 반영
+            DocumentResultDTO documentResult = new DocumentResultDTO();
+            loanSessionService.updateDocumentResult(sessionId, documentResult);
+
             return ResponseEntity.ok(result);
 
         } catch (InterruptedException e) {
@@ -87,8 +94,10 @@ public class DocumentController {
         try {
             log.info("서류 상태 조회 요청: sessionId={}", sessionId);
 
+            // 1. 서류 상태 조회
             Map<String, Object> result = documentService.getDocumentStatus(sessionId);
 
+            // 2. 응답 구성
             Map<String, Object> response = new LinkedHashMap<>();
             response.put("success", true);
             response.putAll(result);
@@ -120,10 +129,14 @@ public class DocumentController {
             @RequestPart("file") MultipartFile file) {
 
         try {
+            // 1. 파일 업로드
             Long documentId = Long.parseLong(documentIdStr);  // String을 Long으로 변환
-            log.info("파일 업로드 요청: sessionId={}, documentId={}", sessionId, documentId);
-
             Map<String, Object> result = documentService.uploadFile(sessionId, documentId, file);
+
+            // 2. 업로드 완료 시에 결과 반영
+            DocumentResultDTO documentResult = new DocumentResultDTO();
+            loanSessionService.updateDocumentResult(sessionId, documentResult);
+
             return ResponseEntity.ok(result);
 
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/guideon/document/controller/LoanSessionController.java
+++ b/src/main/java/com/guideon/document/controller/LoanSessionController.java
@@ -25,15 +25,20 @@ public class LoanSessionController {
     public ResponseEntity<Map<String, Object>> createLoanSession(
             @RequestBody SessionRequest request) {
 
-        try {
-            log.info("대출 세션 생성 요청: businessId={}, policyId={}",
-                    request.getBusinessId(), request.getPolicyId());
+        Map<String, Object> docsResult = null;
+        boolean documentResultCreated = false;
 
-            Map<String, Object> result = loanSessionService.createLoanSession(request);
+        try {
+            Map<String, Object> result = loanSessionService.createLoanSession(request); // 세션 생성
+            docsResult = loanSessionService.createDocsResult(request);  // 세션 결과 생성
+            documentResultCreated = docsResult != null &&
+                    Boolean.TRUE.equals(docsResult.get("success"));
 
             Map<String, Object> response = new LinkedHashMap<>();
+
             response.put("success", true);
             response.putAll(result);
+            response.put("documentResultCreated", documentResultCreated);
 
             return ResponseEntity.ok(response);
 

--- a/src/main/java/com/guideon/document/dto/DocumentResultDTO.java
+++ b/src/main/java/com/guideon/document/dto/DocumentResultDTO.java
@@ -5,14 +5,16 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class DocumentResultDTO {
 
-    private Long memberId;
-    private String policyName;
-    private String sessionStatus;
-    private String progressPercentage;
+    private String policyName;  // 정책자금명 - fund_name
+    private String sessionStatus; //  서류 상태 - doc_session_status
+    private BigDecimal progressPercentage; // 서류 진행률 - doc_score_pct
+    private String step; // 현재 단계 - current_step "DOCS" 로 고정
 }

--- a/src/main/java/com/guideon/document/mapper/LoanSessionMapper.java
+++ b/src/main/java/com/guideon/document/mapper/LoanSessionMapper.java
@@ -1,6 +1,7 @@
 package com.guideon.document.mapper;
 
 import com.guideon.document.domain.LoanSessionVO;
+import com.guideon.document.dto.DocumentResultDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -33,4 +34,16 @@ public interface LoanSessionMapper {
     LoanSessionVO selectByBusinessIdAndPolicyId(@Param("businessId") Long businessId,
                                                 @Param("policyId") Long policyId);
 
+    /**
+     * DocumentResult를 simulation_result 테이블에 저장 (임시)
+     */
+    // 매퍼 인터페이스
+    int insertDocumentResultToSimulation(@Param("businessId") Long businessId,
+                                         @Param("memberId") Long memberId,
+                                         @Param("documentResult") DocumentResultDTO documentResult);
+    /**
+     * DocumentResult를 simulation_result 테이블에 업데이트 (임시)
+     */
+    int updateDocumentResultInSimulation(@Param("businessId") Long businessId,
+                                         @Param("documentResult") DocumentResultDTO documentResult);
 }

--- a/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/DocumentServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -176,8 +177,6 @@ public class DocumentServiceImpl implements DocumentService {
 
         // 3. 서류가 없으면 안내 응답
         if (documents.isEmpty()) {
-            log.info("생성된 서류 없음: sessionId={}", sessionId);
-
             Map<String, Object> response = new LinkedHashMap<>();
             response.put("success", true);
             response.put("sessionId", sessionId);
@@ -188,7 +187,6 @@ public class DocumentServiceImpl implements DocumentService {
             response.put("completedRequirements", 0);
             response.put("progressPercentage", 0.0);
             response.put("message", "서류가 아직 생성되지 않았습니다.");
-
             return response;
         }
 
@@ -219,18 +217,13 @@ public class DocumentServiceImpl implements DocumentService {
                         doc -> doc
                 ));
 
-        // 7. documentGroups에 실제 업로드 상태 반영
-        int totalRequirements = 0;
-        int completedRequirements = 0;
-
+        // 7. documentGroups에 실제 업로드 상태만 반영 (진행률 계산 제거)
         for (Map<String, Object> group : documentGroups) {
             String groupKey = (String) group.get("groupKey");
             Integer minSelect = (Integer) group.get("minSelect");
             List<Map<String, Object>> docs = (List<Map<String, Object>>) group.get("documents");
 
             if (docs != null && minSelect != null) {
-                totalRequirements += minSelect;
-
                 int groupCompletedCount = 0;
 
                 // 각 서류에 실제 상태 정보 추가
@@ -253,13 +246,12 @@ public class DocumentServiceImpl implements DocumentService {
                             doc.put("uploadedAt", uploadedDoc.getUploadedAt());
                         }
 
-                        // 완료된 서류 카운트 (UPLOADED 또는 VALIDATED 상태)
+                        // 완료된 서류 카운트 (진행률 계산은 안하고 UI 표시용으로만)
                         String status = uploadedDoc.getUploadStatus();
                         if ("UPLOADED".equals(status) || "VALIDATED".equals(status)) {
                             groupCompletedCount++;
                         }
 
-                        // status를 uploadStatus로 덮어쓰기 (일관성)
                         doc.put("status", uploadedDoc.getUploadStatus().toLowerCase());
                     } else {
                         // DB에 없으면 기본 상태
@@ -270,38 +262,24 @@ public class DocumentServiceImpl implements DocumentService {
                     }
                 }
 
-                // 그룹별 완료 수는 최소 선택 수로 제한
-                completedRequirements += Math.min(groupCompletedCount, minSelect);
-
                 // 그룹에 완료 정보 추가 (UI에서 사용할 수 있도록)
                 group.put("submitted", Math.min(groupCompletedCount, minSelect));
                 group.put("isCompleted", groupCompletedCount >= minSelect);
             }
         }
 
-        // 8. 전체 진행률 계산
-        double progressPercentage = totalRequirements > 0 ?
-                Math.round((double) completedRequirements / totalRequirements * 100.0 * 100.0) / 100.0 : 0.0;
-
-        // 9. 세션 진행 상태 업데이트
-        loanSessionMapper.updateSessionProgress(sessionId, totalRequirements, completedRequirements, progressPercentage);
-
-        // 10. getRequiredDocuments와 동일한 구조 + 상태 정보
+        // 8. 응답 구성
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("success", true);
         response.put("sessionId", sessionId);
         response.put("policyName", policy.getPolicyName());
-
-        // 핵심: getRequiredDocuments와 동일한 구조
         response.put("documentGroups", documentGroups);
         response.put("totalGroups", documentGroups.size());
+        response.put("totalRequirements", session.getRequiredDocuments() != null ? session.getRequiredDocuments() : 0);
+        response.put("completedRequirements", session.getSubmittedDocuments() != null ? session.getSubmittedDocuments() : 0);
+        response.put("progressPercentage", session.getProgressPercentage() != null ? session.getProgressPercentage() : BigDecimal.ZERO);
 
-        // 추가: 진행률 정보
-        response.put("totalRequirements", totalRequirements);
-        response.put("completedRequirements", completedRequirements);
-        response.put("progressPercentage", progressPercentage);
-
-        log.info("서류 상태 조회 완료: sessionId={}, 진행률={}%", sessionId, progressPercentage);
+        log.info("서류 상태 조회 완료: sessionId={}, 진행률={}%", sessionId, session.getProgressPercentage());
 
         return response;
     }

--- a/src/main/java/com/guideon/document/service/LoanSessionService.java
+++ b/src/main/java/com/guideon/document/service/LoanSessionService.java
@@ -1,9 +1,8 @@
 package com.guideon.document.service;
 
-import com.guideon.document.dto.LoanSessionDTO;
+import com.guideon.document.dto.DocumentResultDTO;
 import com.guideon.document.dto.SessionRequest;
 
-import java.util.List;
 import java.util.Map;
 
 public interface LoanSessionService {
@@ -14,5 +13,15 @@ public interface LoanSessionService {
      * @return 생성/재개된 세션 정보
      */
     Map<String, Object> createLoanSession(SessionRequest request);
+
+    /**
+     * 서류 결과 생성
+     */
+    Map<String, Object> createDocsResult(SessionRequest request);
+
+    /**
+     * 서류 업데이트 시 DocumentResult도 함께 업데이트
+     */
+    void updateDocumentResult(Long sessionId, DocumentResultDTO documentResult);
 
 }

--- a/src/main/java/com/guideon/document/service/LoanSessionServiceImpl.java
+++ b/src/main/java/com/guideon/document/service/LoanSessionServiceImpl.java
@@ -1,17 +1,21 @@
 package com.guideon.document.service;
 
 import com.guideon.document.domain.BusinessInfoVO;
+import com.guideon.document.domain.DocumentUploadsVO;
 import com.guideon.document.domain.LoanSessionVO;
 import com.guideon.document.domain.PolicyVO;
+import com.guideon.document.dto.DocumentResultDTO;
 import com.guideon.document.dto.LoanSessionDTO;
 import com.guideon.document.dto.SessionRequest;
 import com.guideon.document.mapper.BusinessInfoMapper;
+import com.guideon.document.mapper.DocumentUploadsMapper;
 import com.guideon.document.mapper.LoanSessionMapper;
 import com.guideon.document.mapper.PolicyMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +29,8 @@ public class LoanSessionServiceImpl implements LoanSessionService {
     private final BusinessInfoMapper businessInfoMapper;
     private final PolicyMapper policyMapper;
     private final LoanSessionMapper loanSessionMapper;
+    private final DocumentUploadsMapper documentUploadsMapper;
+
 
     @Override
     public Map<String, Object> createLoanSession(SessionRequest request) {
@@ -90,4 +96,136 @@ public class LoanSessionServiceImpl implements LoanSessionService {
         return response;
     }
 
+    /**
+     * 세션 결과 생성
+     */
+    @Override
+    public Map<String, Object> createDocsResult(SessionRequest request) {
+
+        // 1. 기존 세션 조회
+        LoanSessionVO session = loanSessionMapper.selectByBusinessIdAndPolicyId(
+                request.getBusinessId(), request.getPolicyId());
+
+        if (session == null) {
+            throw new IllegalArgumentException("해당 세션을 찾을 수 없습니다.");
+        }
+
+        // 2. 정책자금 정보 조회 (정책명 가져오기)
+        PolicyVO policy = policyMapper.selectByPolicyId(request.getPolicyId());
+
+        // 3. 사업체 정보 조회 (memberId 가져오기)
+        BusinessInfoVO businessInfo = businessInfoMapper.selectByBusinessId(request.getBusinessId());
+        if (businessInfo == null) {
+            throw new IllegalArgumentException("사업체 정보를 찾을 수 없습니다.");
+        }
+
+        // 4. 세션 결과 생성
+        DocumentResultDTO documentResult = DocumentResultDTO.builder()
+                .policyName(policy != null ? policy.getPolicyName() : "정책자금")
+                .sessionStatus(session.getSessionStatus())
+                .progressPercentage(session.getProgressPercentage())
+                .step("DOCS")
+                .build();
+
+        // 5. simulation_result 테이블에 저장
+        boolean success = false;
+        try {
+            int result = loanSessionMapper.insertDocumentResultToSimulation(
+                    request.getBusinessId(),
+                    businessInfo.getMemberId(),
+                    documentResult
+            );
+            success = (result > 0);
+            log.info("DocumentResult 저장 완료: businessId={}, success={}", request.getBusinessId(), success);
+        } catch (Exception e) {
+            log.error("DocumentResult 저장 실패: businessId={}", request.getBusinessId(), e);
+            success = false;
+        }
+
+        // 6. 응답 구성
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("sessionId", session.getId());
+        response.put("documentResult", documentResult);
+
+        log.info("서류 결과 생성 완료: sessionId={}", session.getId());
+
+        return response;
+    }
+
+    /**
+     * 서류 등록 결과 업데이트
+     */
+    @Override
+    public void updateDocumentResult(Long sessionId, DocumentResultDTO documentResult) {
+
+        // 1. 세션 존재 확인
+        LoanSessionVO session = loanSessionMapper.selectById(sessionId);
+        if (session == null) {
+            throw new IllegalArgumentException("존재하지 않는 세션입니다. sessionId: " + sessionId);
+        }
+
+        // 2. 진행률 계산
+        calculateCurrentProgress(sessionId);
+
+        // 3. 업데이트된 세션 정보로 세션 결과 구성
+        LoanSessionVO updatedSession = loanSessionMapper.selectById(sessionId);
+        documentResult.setProgressPercentage(updatedSession.getProgressPercentage());
+        documentResult.setSessionStatus(updatedSession.getSessionStatus());
+        documentResult.setStep("DOCS");
+
+        // 4. simulation_result 테이블 업데이트
+        try {
+            int result = loanSessionMapper.updateDocumentResultInSimulation(
+                    session.getBusinessId(),
+                    documentResult
+            );
+
+            if (result > 0) {
+                log.info("DocumentResult 업데이트 완료: sessionId={}, progress={}",
+                        sessionId, documentResult.getProgressPercentage());
+            } else {
+                log.warn("DocumentResult 업데이트 대상 없음: sessionId={}", sessionId);
+            }
+        } catch (Exception e) {
+            log.error("DocumentResult 업데이트 실패: sessionId={}", sessionId, e);
+            throw new RuntimeException("서류 결과 업데이트에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 세션의 현재 진행률을 계산하고 loan_sessions 테이블 업데이트
+     * @param sessionId
+     */
+    private void calculateCurrentProgress(Long sessionId) {
+        try {
+            log.info("진행률 자동 계산 시작: sessionId={}", sessionId);
+
+            // 1. 서류 목록 조회
+            List<DocumentUploadsVO> documents = documentUploadsMapper.selectBySessionId(sessionId);
+            if (documents.isEmpty()) {
+                log.info("서류가 없어서 진행률 계산 생략: sessionId={}", sessionId);
+                return;
+            }
+
+            // 2. 완료된 서류 카운트
+            int totalDocs = documents.size();
+            int completedDocs = (int) documents.stream()
+                    .filter(doc -> "UPLOADED".equals(doc.getUploadStatus()) ||
+                            "VALIDATED".equals(doc.getUploadStatus()))
+                    .count();
+
+            // 3. 진행률 계산
+            double progressPercentage = totalDocs > 0 ?
+                    Math.round((double) completedDocs / totalDocs * 100.0 * 100.0) / 100.0 : 0.0;
+
+            // 4. loan_sessions 테이블 업데이트
+            loanSessionMapper.updateSessionProgress(sessionId, totalDocs, completedDocs, progressPercentage);
+
+            log.info("진행률 자동 계산 완료: sessionId={}, progress={}% ({}/{})",
+                    sessionId, progressPercentage, completedDocs, totalDocs);
+
+        } catch (Exception e) {
+            log.error("진행률 계산 실패: sessionId={}", sessionId, e);
+        }
+    }
 }

--- a/src/main/resources/com/guideon/document/mapper/LoanSessionMapper.xml
+++ b/src/main/resources/com/guideon/document/mapper/LoanSessionMapper.xml
@@ -49,6 +49,11 @@
         SET required_documents = #{requiredDocuments},
             submitted_documents = #{submittedDocuments},
             progress_percentage = #{progressPercentage},
+            session_status = CASE
+                                 WHEN #{submittedDocuments} >= #{requiredDocuments} AND #{requiredDocuments} > 0
+                                     THEN 'COMPLETED'
+                                 ELSE 'IN_PROGRESS'
+                END,
             updated_at = NOW()
         WHERE id = #{sessionId}
     </update>
@@ -70,4 +75,26 @@
         WHERE business_id = #{businessId} AND policy_id = #{policyId}
     </select>
 
+    <!-- DocumentResult 초기 생성 (임시로 simulation_result에 저장) -->
+    <insert id="insertDocumentResultToSimulation">
+        INSERT INTO simulation_result (
+            member_id, fund_name, current_step, overall_status,
+            doc_session_status, business_id
+        ) VALUES (
+                     #{memberId},
+                     #{documentResult.policyName},
+                     #{documentResult.step},
+                     'IN_PROGRESS',
+                     #{documentResult.sessionStatus},
+                     #{businessId}
+                 )
+    </insert>
+
+    <!-- DocumentResult 업데이트 -->
+    <update id="updateDocumentResultInSimulation">
+        UPDATE simulation_result
+        SET doc_session_status = #{documentResult.sessionStatus},
+            updated_at = NOW()
+        WHERE business_id = #{businessId}
+    </update>
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
서류 업로드/마이데이터 연동 시 시뮬레이션 결과 즉시 반영 기능 구현

## 📖 작업 내용 

### 🔧 **주요 변경사항**
- **서류 업로드/마이데이터 연동 시점에 진행률 즉시 계산 및 시뮬레이션 결과 업데이트**
- **서류 상태 조회 API는 순수 조회 기능으로 변경**
- **세션 기반 서류 등록 플로우 최적화**

### 📋 **세부 구현 내용**

#### 1. **LoanSessionServiceImpl.java 개선**
- `updateDocumentResult()` 메서드에 진행률 자동 계산 기능 추가
- `calculateCurrentProgress()` private 메서드 신규 구현
  - 서류 목록 조회 → 완료된 서류 카운트 → 진행률 계산 → loan_sessions 테이블 업데이트
- `DocumentUploadsMapper` 의존성 추가

#### 2. **DocumentController.java 최적화**
- `uploadFile()`: 파일 업로드 완료 후 `updateDocumentResult()` 즉시 호출
- `syncWithMyData()`: 마이데이터 연동 완료 후 `updateDocumentResult()` 즉시 호출  
- `getDocumentStatus()`: 불필요한 업데이트 로직 제거, 순수 조회만 수행

#### 3. **DocumentServiceImpl.java 리팩토링**
- `getDocumentStatus()` 메서드에서 진행률 계산 로직 제거
- DB에서 이미 계산된 진행률 값을 사용하도록 변경

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#37`)

## ✋ 질문 사항

## 🔗 관련 이슈
* #37