### PR TITLE
fix: 신용평가 결과 조회 시 시뮬레이션 결과에 저장 및 단계 이동 반영

### DIFF
--- a/src/main/java/com/guideon/document/controller/LoanSessionController.java
+++ b/src/main/java/com/guideon/document/controller/LoanSessionController.java
@@ -61,17 +61,17 @@ public class LoanSessionController {
     /**
      * 현재 진행 단계 조회
      */
-    @GetMapping("/step/{businessId}")
+    @GetMapping("/step/{sessionId}")
     public ResponseEntity<Map<String, Object>> getCurrentStep(
-            @PathVariable Long businessId) {
+            @PathVariable Long sessionId) {
 
         try {
-            String currentStep = loanSessionService.getCurrentStep(businessId);
+            String currentStep = loanSessionService.getCurrentStep(sessionId);
 
             return ResponseEntity.ok(Map.of(
                     "success", true,
                     "currentStep", currentStep,
-                    "businessId", businessId
+                    "sessionId", sessionId
             ));
 
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/guideon/document/service/LoanSessionService.java
+++ b/src/main/java/com/guideon/document/service/LoanSessionService.java
@@ -27,6 +27,6 @@ public interface LoanSessionService {
     /**
      * 현재 진행 단계 조회
      */
-    String getCurrentStep(Long businessId);
+    String getCurrentStep(Long sessionId);
 
 }

--- a/src/main/java/com/guideon/hybridEvaluation/mapper/CreditEvaluationResultMapper.java
+++ b/src/main/java/com/guideon/hybridEvaluation/mapper/CreditEvaluationResultMapper.java
@@ -65,4 +65,10 @@ public interface CreditEvaluationResultMapper {
      * @return 전체 개수
      */
     int countCreditEvaluationResults();
+
+    /**
+     * 신용평가 결과를 simulation_result 테이블에 반영 (traditional_credit_score만)
+     */
+    int updateSimulationResultWithCreditScore(@Param("sessionId") Long sessionId,
+                                              @Param("totalScore") Integer totalScore);
 }

--- a/src/main/java/com/guideon/hybridEvaluation/service/CreditEvaluationServiceImpl.java
+++ b/src/main/java/com/guideon/hybridEvaluation/service/CreditEvaluationServiceImpl.java
@@ -73,17 +73,29 @@ public class CreditEvaluationServiceImpl implements CreditEvaluationService {
                     // 신용점수 계산 및 저장
                     try {
                         CreditEvaluationResult scoreResult = creditScoreCalculationService.calculateCreditScore(savedData);
-                        
+
                         // 기존 결과가 있다면 삭제 후 새로 저장
                         if (creditEvaluationResultMapper.existsCreditEvaluationResult(scoreResult.getSessionId())) {
                             creditEvaluationResultMapper.deleteCreditEvaluationResult(scoreResult.getSessionId());
                             log.info("기존 신용점수 결과 삭제됨: sessionId={}", scoreResult.getSessionId());
                         }
-                        
+
+                        // credit_evaluation_result 테이블에 저장
                         creditEvaluationResultMapper.insertCreditEvaluationResult(scoreResult);
-                        log.info("신용점수 계산 및 저장 완료: sessionId={}, totalScore={}", 
+                        log.info("신용점수 계산 및 저장 완료: sessionId={}, totalScore={}",
                                 scoreResult.getSessionId(), scoreResult.getTotalScore());
-                        
+
+                        // simulation_result 테이블에 traditional_credit_score만 반영 및 단계 변경
+                        int updateResult = creditEvaluationResultMapper.updateSimulationResultWithCreditScore(
+                                scoreResult.getSessionId(), scoreResult.getTotalScore());
+
+                        if (updateResult > 0) {
+                            log.info("simulation_result 테이블 업데이트 완료: sessionId={}, traditional_credit_score={}, step=CREDIT->PLAN",
+                                    scoreResult.getSessionId(), scoreResult.getTotalScore());
+                        } else {
+                            log.warn("simulation_result 테이블 업데이트 실패: sessionId={}", scoreResult.getSessionId());
+                        }
+
                     } catch (Exception scoreException) {
                         log.error("신용점수 계산 중 오류 발생: {}", scoreException.getMessage(), scoreException);
                         // 신용점수 계산 실패해도 신용평가 생성은 성공으로 처리

--- a/src/main/resources/com/guideon/hybridEvaluation/mapper/CreditEvaluationResultMapper.xml
+++ b/src/main/resources/com/guideon/hybridEvaluation/mapper/CreditEvaluationResultMapper.xml
@@ -86,4 +86,17 @@
         FROM credit_evaluation_result
     </select>
 
+    <!-- simulation_result 테이블의 traditional_credit_score만 업데이트 -->
+    <update id="updateSimulationResultWithCreditScore">
+        UPDATE simulation_result
+        SET traditional_credit_score = #{totalScore},
+            credit_last_updated = NOW(),
+            current_step = CASE
+                               WHEN current_step = 'CREDIT' THEN 'PLAN'
+                               ELSE current_step
+                END,
+            updated_at = NOW()
+        WHERE session_id = #{sessionId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request
## 👀 작업 요약
- 신용평가 완료 시 simulation_result 테이블 자동 업데이트 및 단계 전환 로직 구현

## 📖 작업 내용
- 신용평가 결과 저장 시 simulation_result.traditional_credit_score 자동 업데이트
- current_step을 CREDIT → PLAN으로 자동 전환
- 시뮬레이션 플로우의 연속성 보장

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #43 