### PR TITLE
feat: 사업계획서 결과 시뮬 결과에 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,9 @@ dependencies {
     // ====== PDF 추출 ======
     implementation 'org.apache.pdfbox:pdfbox:2.0.30'     // PDF 텍스트 추출
 
+    // ====== Open ai ======
+    implementation "com.openai:openai-java:3.5.1"
+
     // ===== 테스트 관련 의존성 =====
     testImplementation "org.springframework:spring-test:${springVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/src/main/java/com/guideon/config/OpenAIConfig.java
+++ b/src/main/java/com/guideon/config/OpenAIConfig.java
@@ -1,0 +1,15 @@
+package com.guideon.config;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAIConfig {
+    @Bean
+    public OpenAIClient openAIClient() {
+        // OPENAI_API_KEY 환경변수 자동 인식
+        return OpenAIOkHttpClient.fromEnv();
+    }
+}

--- a/src/main/java/com/guideon/config/WebConfig.java
+++ b/src/main/java/com/guideon/config/WebConfig.java
@@ -46,7 +46,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
 
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class[] { RootConfig.class, SecurityConfig.class, RedisConfig.class, MailConfig.class, VisionConfig.class };
+        return new Class[] { RootConfig.class, SecurityConfig.class, RedisConfig.class, MailConfig.class, VisionConfig.class, OpenAIConfig.class };
     }
 
     @Override

--- a/src/main/java/com/guideon/plan/ai/domain/AiEvalResult.java
+++ b/src/main/java/com/guideon/plan/ai/domain/AiEvalResult.java
@@ -1,0 +1,21 @@
+package com.guideon.plan.ai.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AiEvalResult {
+    @JsonPropertyDescription("섹션 가중 득점의 합(0~100). 반올림 없이 원점수.")
+    public double totalScore;
+
+    @JsonPropertyDescription("문서 전반 강점 (최대 5개)")
+    public List<String> strengths;
+
+    @JsonPropertyDescription("문서 전반 리스크/개선 필요 (최대 5개)")
+    public List<String> risks;
+
+    @JsonPropertyDescription("섹션별 결과 목록")
+    public List<AiSectionRow> sections;
+}

--- a/src/main/java/com/guideon/plan/ai/domain/AiSectionRow.java
+++ b/src/main/java/com/guideon/plan/ai/domain/AiSectionRow.java
@@ -1,0 +1,23 @@
+package com.guideon.plan.ai.domain;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonClassDescription("섹션별 평가 결과")
+public class AiSectionRow {
+    @JsonPropertyDescription("plan_eval_section.section_id (DB의 PK)")
+    public long sectionId;
+
+    @JsonPropertyDescription("해당 섹션 가중 득점 (0 ~ 해당 섹션 weight)")
+    public double scorePoints;
+
+    @JsonPropertyDescription("한두 문장 코멘트")
+    public String comment;
+
+    @JsonPropertyDescription("개선 제안 (최대 3개)")
+    public List<String> suggestions;
+}

--- a/src/main/java/com/guideon/plan/ai/prompt/PlanAiPromptBuilder.java
+++ b/src/main/java/com/guideon/plan/ai/prompt/PlanAiPromptBuilder.java
@@ -1,0 +1,35 @@
+package com.guideon.plan.ai.prompt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.guideon.plan.domain.SectionVO;
+
+import java.util.List;
+
+public class PlanAiPromptBuilder {
+    private static final ObjectMapper OM = new ObjectMapper();
+
+    public static String buildSystemPrompt() {
+        return String.join("\n",
+                "역할: 당신은 소상공인 대출 심사 보조 평가관입니다.",
+                "목표: 첨부된 '사업계획서(PDF)'만 근거로 섹션별 가중 득점과 코멘트·개선제안을 산출합니다.",
+                "원칙: 근거 불명확 시 보수적으로 감점. 수치·합계·비율 일치 여부는 엄격히 검증.",
+                "출력: 반드시 지정 JSON 스키마로만 출력(기타 텍스트 출력 금지)."
+        );
+    }
+
+    public static String buildUserPrompt(List<SectionVO> masters) {
+        try {
+            String mastersJson = OM.writeValueAsString(masters); // sectionId, displayLabel, weight, pointsTemplate, formMappings
+            return "다음은 섹션 마스터입니다.\n" +
+                    "\n\n[섹션 마스터(JSON)]\n" + mastersJson +
+                    "\n\n지시사항:\n" +
+                    "1) 각 섹션(sectionId)의 weight 범위 내에서 scorePoints를 산출하세요.\n" +
+                    "2) totalScore는 모든 섹션 scorePoints 합입니다(0~100).\n" +
+                    "3) 각 섹션 comment는 1~2문장, suggestions는 최대 3개로 간결하게.\n" +
+                    "4) strengths/risks는 문서 전반 기준으로 최대 5개씩 도출.\n" +
+                    "5) JSON 외 불필요한 텍스트는 출력하지 마세요.";
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/guideon/plan/controller/PlanEvalController.java
+++ b/src/main/java/com/guideon/plan/controller/PlanEvalController.java
@@ -5,6 +5,7 @@ import com.guideon.plan.parser.PdfPlanExtractor;
 import com.guideon.plan.service.PlanEvalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,5 +25,12 @@ public class PlanEvalController {
     @ResponseBody
     public EvaluationResultDTO get(@PathVariable("sessionId") Long sessionId) {
         return planEvalService.getByReportId(sessionId);
+    }
+
+    @PostMapping("/session/{sessionId}/evaluate/ai")
+    @ResponseBody
+    public ResponseEntity<Void> evaluateWithAi(@PathVariable Long sessionId) throws Exception {
+        planEvalService.evaluateSessionWithAI(sessionId);
+        return ResponseEntity.noContent().build(); // 204
     }
 }

--- a/src/main/java/com/guideon/plan/parser/PdfPlanExtractor.java
+++ b/src/main/java/com/guideon/plan/parser/PdfPlanExtractor.java
@@ -48,7 +48,7 @@ public class PdfPlanExtractor {
             ts.setStartPage(1);
             ts.setEndPage(doc.getNumberOfPages());   // 전체 페이지 명시
             String raw = ts.getText(doc);
-            // log.debug("PDF text (len={}):\n{}", raw.length(), raw);
+            log.debug("PDF text (len={}):\n{}", raw.length(), raw);
             return parse(raw);
         }
     }

--- a/src/main/java/com/guideon/plan/service/PlanEvalService.java
+++ b/src/main/java/com/guideon/plan/service/PlanEvalService.java
@@ -5,5 +5,6 @@ import com.guideon.plan.parser.PdfPlanExtractor;
 
 public interface PlanEvalService {
     PdfPlanExtractor evaluateDocument(Long sessionId) throws Exception;
+    void evaluateSessionWithAI(Long sessionId) throws Exception;
     EvaluationResultDTO getByReportId(Long reportId);
 }

--- a/src/main/java/com/guideon/plan/service/PlanEvalServiceImpl.java
+++ b/src/main/java/com/guideon/plan/service/PlanEvalServiceImpl.java
@@ -1,7 +1,10 @@
 package com.guideon.plan.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guideon.document.domain.DocumentUploadsVO;
 import com.guideon.document.service.DocumentService;
+import com.guideon.plan.ai.domain.AiEvalResult;
+import com.guideon.plan.ai.prompt.PlanAiPromptBuilder;
 import com.guideon.plan.domain.*;
 import com.guideon.plan.dto.EvaluationResultDTO;
 import com.guideon.plan.dto.SectionDetailDTO;
@@ -10,6 +13,13 @@ import com.guideon.plan.parser.PdfPlanExtractor;
 import com.guideon.plan.policy.GradePolicy;
 import com.guideon.plan.rule.PlanEvalRules;
 import com.guideon.security.util.LoginUserProvider;
+import com.guideon.simulation.result.service.SimulationResultService;
+import com.openai.client.OpenAIClient;
+import com.openai.models.ChatModel;
+import com.openai.models.files.FileCreateParams;
+import com.openai.models.files.FileObject;
+import com.openai.models.files.FilePurpose;
+import com.openai.models.responses.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,9 +34,13 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class PlanEvalServiceImpl implements PlanEvalService{
+    private final OpenAIClient openAIClient;
     private final PlanEvalMapper mapper;
     private final DocumentService documentService;
+    private final SimulationResultService simulationResultService;
     private final LoginUserProvider loginUserProvider;
+
+    private static final ObjectMapper OM = new ObjectMapper();
 
     private static final String GROUP_BUSINESS_PLAN = "business_plan";
 
@@ -37,7 +51,7 @@ public class PlanEvalServiceImpl implements PlanEvalService{
 
         // 문서 조회 (파일 경로 필수)
         DocumentUploadsVO doc = documentService.getDocument(sessionId, GROUP_BUSINESS_PLAN);
-        if (doc == null) throw new IllegalArgumentException("document not found");
+        if (doc == null) throw new IllegalArgumentException("business_plan 문서를 찾을 수 없습니다. sessionId=" + sessionId);
         if (doc.getFilePath() == null) throw new IllegalStateException("file_path is null for documentId=" + doc.getId());
 
         Path path = Paths.get(doc.getFilePath());
@@ -88,8 +102,111 @@ public class PlanEvalServiceImpl implements PlanEvalService{
                     .build();
             mapper.insertSectionResult(row);
         }
+        simulationResultService.updateSimulationStatus(sessionId, total);
 
         return fx;
+    }
+
+    @Transactional
+    public void evaluateSessionWithAI(Long sessionId) throws Exception {
+        Long memberId = loginUserProvider.getLoginMemberId();
+
+        // 문서 조회 (파일 경로 필수)
+        DocumentUploadsVO doc = documentService.getDocument(sessionId, GROUP_BUSINESS_PLAN);
+        if (doc == null) throw new IllegalArgumentException("business_plan 문서를 찾을 수 없습니다. sessionId=" + sessionId);
+        if (doc.getFilePath() == null) throw new IllegalStateException("file_path is null for documentId=" + doc.getId());
+
+
+        Path pdf =Paths.get(doc.getFilePath());
+        if (!Files.exists(pdf)) {
+            throw new IllegalStateException("파일이 존재하지 않습니다: " + pdf);
+        }
+
+        // 1) 섹션 마스터
+        List<SectionVO> masters = mapper.selectSection();
+
+        // 2) PDF 업로드 (purpose=INPUT)
+        FileObject uploaded = openAIClient.files().create(
+                FileCreateParams.builder()
+                        .file(pdf)                          // java.nio.file.Path OK (File 아님)
+                        .purpose(FilePurpose.ASSISTANTS)         // Responses/Assistants 입력용
+                        .build()
+        );
+
+        // 3) 프롬프트
+        String system = PlanAiPromptBuilder.buildSystemPrompt();
+        String userPrompt = PlanAiPromptBuilder.buildUserPrompt(masters);
+        //  - userPrompt 안에서 "이 형식의 JSON만 출력" 가이드를 꼭 넣어두세요 (예: code block 금지, 설명문 금지 등)
+
+        // 4) Responses 입력 구성
+        List<ResponseInputItem> inputs = List.of(
+                ResponseInputItem.ofMessage(
+                        ResponseInputItem.Message.builder()
+                                .role(ResponseInputItem.Message.Role.SYSTEM)
+                                .addInputTextContent(system)
+                                .build()
+                ),
+                ResponseInputItem.ofMessage(
+                        ResponseInputItem.Message.builder()
+                                .role(ResponseInputItem.Message.Role.USER)
+                                .addInputTextContent(userPrompt)
+                                // PDF 파일을 메시지에 첨부(모델이 참조할 수 있게)
+                                .addContent(
+                                        ResponseInputFile.builder()
+                                                .fileId(uploaded.id())  // FileObject.id()
+                                                .build()
+                                )
+                                .build()
+                )
+        );
+
+        // 5) 호출 (단순 텍스트 응답 → JSON 파싱)
+        ResponseCreateParams params = ResponseCreateParams.builder()
+                .model(ChatModel.GPT_4_1_MINI)                         // 필요시 모델 상향
+                .input(ResponseCreateParams.Input.ofResponse(inputs))  // ← 핵심
+                .maxOutputTokens(1200)
+                .build();
+
+        Response res = openAIClient.responses().create(params);
+
+        // 6) 응답 텍스트 모으기 (content().outputText())
+        String raw = res.output().stream()
+                .flatMap(o -> o.message().stream())
+                .flatMap(m -> m.content().stream())
+                .flatMap(c -> c.outputText().stream())
+                .map(ResponseOutputText::text)
+                .collect(Collectors.joining("\n"));
+
+        // 7) JSON → DTO 역직렬화
+        //    모델 프롬프트에서 AiEvalResult 스키마 그대로 출력하도록 강제해야 함
+        AiEvalResult ai = OM.readValue(raw, AiEvalResult.class);
+
+        // 총점 반올림
+        double total = Math.round(ai.getTotalScore() * 100.0) / 100.0;
+
+        // 8) DB 저장
+        PlanEvalReportVO report = PlanEvalReportVO.builder()
+                .memberId(memberId)
+                .documentId(doc.getId())
+                .totalScore(total)
+                .strengths(ai.getStrengths())
+                .risks(ai.getRisks())
+                .build();
+        mapper.insertReport(report);
+        Long reportId = report.getReportId();
+
+        ai.getSections().forEach(s ->
+                mapper.insertSectionResult(
+                        PlanEvalSectionResultVO.builder()
+                                .reportId(reportId)
+                                .sectionId(s.getSectionId())
+                                .scorePoints(s.getScorePoints())
+                                .comment(s.getComment())
+                                .suggestions(s.getSuggestions())
+                                .build()
+                )
+        );
+        simulationResultService.updateSimulationStatus(sessionId, total);
     }
 
     /** 최소 데이터만 반환 */

--- a/src/main/java/com/guideon/simulation/result/mapper/SimulationResultMapper.java
+++ b/src/main/java/com/guideon/simulation/result/mapper/SimulationResultMapper.java
@@ -21,4 +21,6 @@ public interface SimulationResultMapper {
 
     /** 최근 COMPLETED 1건의 total_probability_pct */
     Double findLatestCompletedProbability(@Param("memberId") Long memberId);
+
+    void updatePlanResult(@Param("sessionId") Long sessionId, @Param("planTotalScore") double planTotalScore);
 }

--- a/src/main/java/com/guideon/simulation/result/service/SimulationResultService.java
+++ b/src/main/java/com/guideon/simulation/result/service/SimulationResultService.java
@@ -11,4 +11,6 @@ public interface SimulationResultService {
 
     /** 홈 요약 */
     HomeSummaryDto getHomeSummary(Long memberId);
+
+    void updateSimulationStatus(Long sessionId, double planTotalScore);
 }

--- a/src/main/java/com/guideon/simulation/result/service/SimulationResultServiceImpl.java
+++ b/src/main/java/com/guideon/simulation/result/service/SimulationResultServiceImpl.java
@@ -11,7 +11,6 @@ import com.guideon.simulation.result.dto.SimulationResultDetailDto;
 import com.guideon.simulation.result.dto.SimulationResultListDto;
 import com.guideon.simulation.result.exception.NotFoundException;
 import com.guideon.simulation.result.mapper.SimulationResultMapper;
-import com.guideon.simulation.result.service.SimulationResultService;
 import com.guideon.simulation.result.dto.HomeSummaryDto;
 
 import lombok.RequiredArgsConstructor;
@@ -90,5 +89,10 @@ public class SimulationResultServiceImpl implements SimulationResultService {
         Double recent = mapper.findLatestCompletedProbability(memberId);
         Integer recentRounded = (recent == null) ? null : (int)Math.round(recent);
         return new HomeSummaryDto(joined, inProgress, recentRounded);
+    }
+
+    @Override
+    public void updateSimulationStatus(Long sessionId, double planTotalScore) {
+        mapper.updatePlanResult(sessionId, planTotalScore);
     }
 }

--- a/src/main/resources/com/guideon/simulation/result/mapper/SimulationResultMapper.xml
+++ b/src/main/resources/com/guideon/simulation/result/mapper/SimulationResultMapper.xml
@@ -71,4 +71,12 @@
             LIMIT 1
     </select>
 
+    <update id="updatePlanResult">
+        UPDATE simulation_result
+        SET plan_total_score = #{planTotalScore},
+            current_step = 'RESULT',
+            overall_status = 'COMPLETED',
+            updated_at = CURRENT_TIMESTAMP
+        WHERE session_id = #{sessionId}
+    </update>
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
- simulation_result 테이블 업데이트용 Mapper 메서드 추가

## 📖 작업 내용 
- plan_total_score 업데이트 및 current_step = 'RESULT', overall_status = 'COMPLETED'로 변경하는 SQL 작성
- session_id 기준으로 대상 행 업데이트
- MyBatis updatePlanResult 쿼리 추가 (파라미터: planTotalScore, sessionId)

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: closes #1234)
